### PR TITLE
Add default name for task definition macro

### DIFF
--- a/celery-codegen/src/error.rs
+++ b/celery-codegen/src/error.rs
@@ -11,10 +11,6 @@ pub(crate) struct Error {
 }
 
 impl Error {
-    pub(crate) fn new(message: impl Into<String>) -> Self {
-        Error::spanned(message, Span::call_site())
-    }
-
     pub(crate) fn spanned(message: impl Into<String>, span: Span) -> Self {
         Error {
             message: message.into(),

--- a/examples/celery.rs
+++ b/examples/celery.rs
@@ -1,29 +1,13 @@
 use async_trait::async_trait;
 use celery::AMQPBroker;
-use celery::{Celery, Error, Task};
+use celery::{task, Celery};
 use exitfailure::ExitFailure;
-use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
-#[derive(Serialize, Deserialize)]
-struct AddTask {
-    x: i32,
-    y: i32,
-}
-
-#[async_trait]
-impl Task for AddTask {
-    const NAME: &'static str = "add";
-
-    type Returns = i32;
-
-    fn arg_names() -> Vec<String> {
-        vec!["x".into(), "y".into()]
-    }
-
-    async fn run(&mut self) -> Result<i32, Error> {
-        Ok(self.x + self.y)
-    }
+// This generates the task struct and impl with the name set to the function name "add"
+#[task]
+pub fn add(x: i32, y: i32) -> i32 {
+    x + y
 }
 
 #[derive(Debug, StructOpt)]
@@ -53,14 +37,14 @@ async fn main() -> Result<(), ExitFailure> {
     let mut celery = Celery::builder("celery", broker)
         .default_queue_name(queue)
         .build();
-    celery.register_task::<AddTask>()?;
+    celery.register_task::<add>()?;
 
     match opt {
         CeleryOpt::Consume => {
             celery.consume(queue).await?;
         }
         CeleryOpt::Produce => {
-            let task = AddTask { x: 1, y: 2 };
+            let task = add { x: 1, y: 2 };
             celery.send_task(task, queue).await?;
         }
     };

--- a/examples/celery.rs
+++ b/examples/celery.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 
 // This generates the task struct and impl with the name set to the function name "add"
 #[task]
+fn add(x: i32, y: i32) -> i32 {
     x + y
 }
 


### PR DESCRIPTION
Remove required name error and use the function ident for the name by default
Suppress non_camel_case_types for struct name