### PR TITLE
catch SIGINT (CTRL-C) interrupt in consume loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "celery"
 [dependencies]
 celery-codegen = { version = "0.1.0-alpha.1", path = "./celery-codegen", optional = true }
 chrono = "0.4"
-tokio = { version = "0.2", features = ["time", "rt-core", "signal", "stream"]}
+tokio = { version = "0.2", features = ["full"]}
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 failure = "0.1"
@@ -40,7 +40,6 @@ rand = "0.7"
 exitfailure = "0.5.1"
 structopt = "0.3"
 lazy_static = "1.4"
-tokio = { version = "0.2", features = ["rt-threaded", "fs", "macros"] }
 
 [features]
 default = ["codegen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "celery"
 [dependencies]
 celery-codegen = { version = "0.1.0-alpha.1", path = "./celery-codegen", optional = true }
 chrono = "0.4"
-tokio = { version = "0.2", features = ["time", "rt-core"]}
+tokio = { version = "0.2", features = ["time", "rt-core", "signal", "stream"]}
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 failure = "0.1"
@@ -32,7 +32,7 @@ lapin = { version = "0.28.3", features = ["default", "futures"] }
 amq-protocol-types = "3.1"
 log = "0.4"
 env_logger = "0.7"
-futures = "0.3"
+futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}
 rand = "0.7"
 

--- a/examples/celery.rs
+++ b/examples/celery.rs
@@ -3,6 +3,7 @@ use celery::{task, AMQPBroker, Celery, ErrorKind};
 use exitfailure::ExitFailure;
 use lazy_static::lazy_static;
 use structopt::StructOpt;
+use tokio::time::{self, Duration};
 
 // This generates the task struct and impl with the name set to the function name "add"
 #[task]
@@ -14,6 +15,11 @@ fn add(x: i32, y: i32) -> i32 {
 fn buggy_task() {
     #[allow(clippy::try_err)]
     Err(ErrorKind::UnexpectedError("a bug caused this".into()))?
+}
+
+#[task]
+fn long_running_task() {
+    time::delay_for(Duration::from_secs(10)).await;
 }
 
 #[derive(Debug, StructOpt)]
@@ -51,6 +57,7 @@ async fn main() -> Result<(), ExitFailure> {
                 .build();
             celery.register_task::<add>().unwrap();
             celery.register_task::<buggy_task>().unwrap();
+            celery.register_task::<long_running_task>().unwrap();
             celery
         };
     }

--- a/examples/celery_app.py
+++ b/examples/celery_app.py
@@ -13,11 +13,12 @@ def add(x, y):
 
 
 if __name__ == "__main__":
-    add.apply_async(args=[1, 0], countdown=5, expires=2)
+    #  add.apply_async(args=[1, 0], countdown=5, expires=2)
     add.apply_async(args=[1, 1], countdown=5)
-    add.apply_async(args=[1, 1])
-    add.apply_async(args=[1, 2], countdown=10)
-    add.apply_async(args=[1, 3], countdown=10)
-    add.apply_async(args=[2, 4], countdown=10)
-    add.apply_async(args=[2, 5], countdown=10)
+    #  add.apply_async(args=[1, 1])
+    #  add.apply_async(args=[1, 2], countdown=10)
+    #  add.apply_async(args=[1, 3], countdown=10)
+    #  add.apply_async(args=[2, 4], countdown=10)
+    #  add.apply_async(args=[2, 5], countdown=10)
     #  app.send_task("buggy_task")
+    #  app.send_task("long_running_task")

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,7 +21,7 @@ where
 }
 
 #[derive(Copy, Clone, Default)]
-pub(crate) struct TaskOptions {
+struct TaskOptions {
     timeout: Option<usize>,
     max_retries: Option<usize>,
     min_retry_delay: usize,
@@ -40,14 +40,14 @@ impl TaskOptions {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum TaskStatus {
+enum TaskStatus {
     Pending,
     Finished,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct TaskEvent {
-    pub(crate) status: TaskStatus,
+struct TaskEvent {
+    status: TaskStatus,
 }
 
 impl TaskEvent {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -51,7 +51,7 @@ struct TaskEvent {
 }
 
 impl TaskEvent {
-    pub(crate) fn new(status: TaskStatus) -> Self {
+    fn new(status: TaskStatus) -> Self {
         Self { status }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -320,7 +320,7 @@ where
             // Warm shutdown loop. When there are still pendings tasks we wait for them
             // to finish. We get updates about pending tasks through the `event_rx` channel.
             // We also watch for a second SIGINT, in which case we immediately shutdown.
-            info!("Waiting on {} pending tasks", pending_tasks);
+            info!("Waiting on {} pending tasks...", pending_tasks);
             loop {
                 select! {
                     _ = signals.next() => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::sync::RwLock;
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::mpsc::{self, UnboundedSender};
 
 mod trace;
 
@@ -35,6 +36,23 @@ impl TaskOptions {
             min_retry_delay: task.min_retry_delay().unwrap_or(self.min_retry_delay),
             max_retry_delay: task.max_retry_delay().unwrap_or(self.max_retry_delay),
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum TaskStatus {
+    Pending,
+    Finished,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TaskEvent {
+    pub(crate) status: TaskStatus,
+}
+
+impl TaskEvent {
+    pub(crate) fn new(status: TaskStatus) -> Self {
+        Self { status }
     }
 }
 
@@ -111,10 +129,20 @@ where
 
 /// A `Celery` app is used to produce or consume tasks asyncronously.
 pub struct Celery<B: Broker> {
+    /// An arbitrary, human-readable name for the app.
     pub name: String,
+
+    /// The app's broker.
     pub broker: B,
+
+    /// The default queue to send and receive from.
     pub default_queue_name: String,
+
+    /// Mapping of task name to task tracer factory. Used to create a task tracer
+    /// from an incoming message.
     task_trace_builders: RwLock<HashMap<String, TraceBuilder>>,
+
+    /// Default task options.
     task_options: TaskOptions,
 }
 
@@ -156,13 +184,17 @@ where
         }
     }
 
-    fn get_task_tracer(&self, message: Message) -> Result<Box<dyn TracerTrait>, Error> {
+    fn get_task_tracer(
+        &self,
+        message: Message,
+        event_tx: UnboundedSender<TaskEvent>,
+    ) -> Result<Box<dyn TracerTrait>, Error> {
         let task_trace_builders = self
             .task_trace_builders
             .read()
             .map_err(|_| Error::from(ErrorKind::SyncError))?;
         if let Some(build_tracer) = task_trace_builders.get(&message.headers.task) {
-            Ok(build_tracer(message, self.task_options)?)
+            Ok(build_tracer(message, self.task_options, event_tx)?)
         } else {
             Err(ErrorKind::UnregisteredTaskError(message.headers.task).into())
         }
@@ -173,6 +205,7 @@ where
     async fn try_handle_delivery(
         &self,
         delivery_result: Result<B::Delivery, B::DeliveryError>,
+        event_tx: UnboundedSender<TaskEvent>,
     ) -> Result<(), Error> {
         let delivery = delivery_result.map_err(|e| e.into())?;
         debug!("Received delivery: {:?}", delivery);
@@ -185,7 +218,7 @@ where
             }
         };
 
-        let mut tracer = match self.get_task_tracer(message) {
+        let mut tracer = match self.get_task_tracer(message, event_tx) {
             Ok(tracer) => tracer,
             Err(e) => {
                 self.broker.ack(delivery).await?;
@@ -227,36 +260,91 @@ where
     }
 
     /// Wraps `try_handle_delivery` to catch any and all errors that might occur.
-    async fn handle_delivery(&self, delivery_result: Result<B::Delivery, B::DeliveryError>) {
-        if let Err(e) = self.try_handle_delivery(delivery_result).await {
+    async fn handle_delivery(
+        &self,
+        delivery_result: Result<B::Delivery, B::DeliveryError>,
+        event_tx: UnboundedSender<TaskEvent>,
+    ) {
+        if let Err(e) = self.try_handle_delivery(delivery_result, event_tx).await {
             error!("{}", e);
         }
     }
 
     /// Consume tasks from a queue.
     pub async fn consume(&'static self, queue: &str) -> Result<(), Error> {
+        // Stream of deliveries from the queue.
         let mut deliveries = Box::pin(self.broker.consume(queue).await?.fuse());
+
+        // Stream of OS signals.
         let mut signals = signal(SignalKind::interrupt())?.fuse();
-        let mut signal_already_received = false;
+
+        // A sender and receiver for task related events.
+        // NOTE: we can use an unbounded channel since we already have backpressure
+        // from the `prefetch_count` setting.
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<TaskEvent>();
+        let mut event_rx = event_rx.fuse();
+        let mut pending_tasks = 0;
+
+        // This is the main loop where we receive deliveries and pass them off
+        // to be handled by spawning `self.handle_delivery`.
+        // At the same time we are also listening for a SIGINT (Ctrl+C) interruption.
+        // If that occurs we break from this loop and move to the warm shutdown loop
+        // if there are still any pending tasks (tasks being executed, not including
+        // tasks being delayed due to a future ETA).
         loop {
             select! {
                 maybe_delivery_result = deliveries.next() => {
                     if let Some(delivery_result) = maybe_delivery_result {
-                        tokio::spawn(self.handle_delivery(delivery_result));
+                        let event_tx = event_tx.clone();
+                        tokio::spawn(self.handle_delivery(delivery_result, event_tx));
                     }
                 },
                 _ = signals.next() => {
-                    if !signal_already_received {
-                        signal_already_received = true;
-                        warn!("Hitting Ctrl+C again will terminate all running tasks!");
-                        info!("Warm shutdown...");
-                    } else {
-                        warn!("Shutting down now");
-                        break;
+                    warn!("Ope! Hitting Ctrl+C again will terminate all running tasks!");
+                    info!("Warm shutdown...");
+                    break;
+                },
+                maybe_event = event_rx.next() => {
+                    if let Some(event) = maybe_event {
+                        debug!("Received task event {:?}", event);
+                        match event.status {
+                            TaskStatus::Pending => pending_tasks += 1,
+                            TaskStatus::Finished => pending_tasks -= 1,
+                        };
                     }
                 },
             };
         }
+
+        if pending_tasks > 0 {
+            // Warm shutdown loop. When there are still pendings tasks we wait for them
+            // to finish. We get updates about pending tasks through the `event_rx` channel.
+            // We also watch for a second SIGINT, in which case we immediately shutdown.
+            info!("Waiting on {} pending tasks", pending_tasks);
+            loop {
+                select! {
+                    _ = signals.next() => {
+                        warn!("Okay fine, shutting down now. See ya!");
+                        return Err(ErrorKind::ForcedShutdown.into());
+                    },
+                    maybe_event = event_rx.next() => {
+                        if let Some(event) = maybe_event {
+                            debug!("Received task event {:?}", event);
+                            match event.status {
+                                TaskStatus::Pending => pending_tasks += 1,
+                                TaskStatus::Finished => pending_tasks -= 1,
+                            };
+                            if pending_tasks <= 0 {
+                                break;
+                            }
+                        }
+                    },
+                };
+            }
+        }
+
+        info!("No more pending tasks. See ya!");
+
         Ok(())
     }
 }

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -109,6 +109,8 @@ where
         self.event_tx
             .send(TaskEvent::new(TaskStatus::Pending))
             .unwrap_or_else(|_| {
+                // This really shouldn't happen. If it does, there's probably much
+                // bigger things to worry about like running out of memory.
                 error!("Failed sending task event");
             });
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,10 @@ pub enum ErrorKind {
     /// An IO error.
     #[fail(display = "An IO error occured ({:?})", _0)]
     IoError(tokio::io::ErrorKind),
+
+    /// Forced shutdown.
+    #[fail(display = "Forced shutdown")]
+    ForcedShutdown,
 }
 
 impl Fail for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum ErrorKind {
     #[fail(display = "Unknown queue '{}'", _0)]
     UnknownQueueError(String),
 
-    /// An error that is expected to happen every once in a while and should trigger be
+    /// An error that is expected to happen every once in a while and should trigger
     /// the task to be retried without causes a fit.
     #[fail(display = "{}", _0)]
     ExpectedError(String),
@@ -55,6 +55,10 @@ pub enum ErrorKind {
     /// When a mutex is poisened, for example.
     #[fail(display = "Sync error")]
     SyncError,
+
+    /// An IO error.
+    #[fail(display = "An IO error occured ({:?})", _0)]
+    IoError(tokio::io::ErrorKind),
 }
 
 impl Fail for Error {
@@ -116,6 +120,14 @@ impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Error {
         Error {
             inner: Context::new(ErrorKind::SerializationError(err)),
+        }
+    }
+}
+
+impl From<tokio::io::Error> for Error {
+    fn from(err: tokio::io::Error) -> Error {
+        Error {
+            inner: Context::new(ErrorKind::IoError(err.kind())),
         }
     }
 }


### PR DESCRIPTION
closes #52 

Still TODO:
- [x] keep track of tasks that are currently being traced and wait for them to finish