### PR TITLE
make task.run consume self

### DIFF
--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -370,7 +370,7 @@ impl ToTokens for Task {
 
                     type Returns = #ret_ty;
 
-                    async fn run(&mut self) -> Result<Self::Returns, #krate::Error> {
+                    async fn run(mut self) -> Result<Self::Returns, #krate::Error> {
                         #deserialized_bindings
                         Ok(#inner_block)
                     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -301,7 +301,7 @@ mod tests {
 
         type Returns = ();
 
-        async fn run(&mut self) -> Result<(), Error> {
+        async fn run(mut self) -> Result<(), Error> {
             Ok(())
         }
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -38,7 +38,7 @@ use crate::error::Error;
 ///
 ///     type Returns = i32;
 ///
-///     async fn run(&mut self) -> Result<Self::Returns, Error> {
+///     async fn run(mut self) -> Result<Self::Returns, Error> {
 ///         Ok(self.x + self.y)
 ///     }
 /// }
@@ -87,7 +87,7 @@ use crate::error::Error;
 /// #     const NAME: &'static str = "add";
 /// #     const ARGS: &'static [&'static str] = &["x", "y"];
 /// #     type Returns = i32;
-/// #     async fn run(&mut self) -> Result<Self::Returns, Error> {
+/// #     async fn run(mut self) -> Result<Self::Returns, Error> {
 /// #         Ok(self.x + self.y)
 /// #     }
 /// # }
@@ -129,17 +129,17 @@ pub trait Task: Send + Sync + Serialize + for<'de> Deserialize<'de> {
     type Returns: Send + Sync + std::fmt::Debug;
 
     /// This function defines how a task executes.
-    async fn run(&mut self) -> Result<Self::Returns, Error>;
+    async fn run(mut self) -> Result<Self::Returns, Error>;
 
     /// This is a callback function that will run after a task fails.
     /// The argument to the function is the error returned by the task.
     #[allow(unused_variables)]
-    async fn on_failure(&mut self, err: &Error) {}
+    async fn on_failure(err: &Error) {}
 
     /// This is a callback funtion that will run after a task completes
     /// successfully. The argument to the function is the returned value of the task.
     #[allow(unused_variables)]
-    async fn on_success(&mut self, returned: &Self::Returns) {}
+    async fn on_success(returned: &Self::Returns) {}
 
     /// Default timeout for this task.
     fn timeout(&self) -> Option<u32> {

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -43,3 +43,8 @@ fn test_task_options() {
     assert_eq!(t.min_retry_delay(), Some(0));
     assert_eq!(t.max_retry_delay(), Some(60));
 }
+
+#[task]
+fn task_with_strings(s1: String, s2: String) {
+    println!("{}, {}", s1, s2);
+}


### PR DESCRIPTION
Need this to handle task parameters with types that don't implement Copy, such as Strings.