### PR TITLE
don't treat tasks as functions to avoid confusion

### DIFF
--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -353,7 +353,7 @@ impl ToTokens for Task {
             }
 
             impl #wrapper {
-                #vis fn s(#original_args) -> Self {
+                #vis fn new(#original_args) -> Self {
                     #wrapper {
                         #wrapper_fields
                     }

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -24,7 +24,7 @@ fn buggy_task() {
 // Demonstrates a long running IO-bound task. By increasing the prefetch count, an arbitrary
 // number of these number can execute concurrently.
 #[task]
-fn long_running_task() {
+async fn long_running_task() {
     time::delay_for(Duration::from_secs(10)).await;
 }
 
@@ -59,11 +59,11 @@ async fn main() -> Result<(), ExitFailure> {
         }
         CeleryOpt::Produce => {
             // Basic sending.
-            my_app.send_task(add(1, 2)).await?;
+            my_app.send_task(add::s(1, 2)).await?;
 
             // Demonstrates sending a task with additional options.
             let send_options = TaskSendOptions::builder().countdown(10).build();
-            my_app.send_task_with(add(1, 3), &send_options).await?;
+            my_app.send_task_with(add::s(1, 3), &send_options).await?;
         }
     };
 

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -59,11 +59,11 @@ async fn main() -> Result<(), ExitFailure> {
         }
         CeleryOpt::Produce => {
             // Basic sending.
-            my_app.send_task(add::s(1, 2)).await?;
+            my_app.send_task(add::new(1, 2)).await?;
 
             // Demonstrates sending a task with additional options.
             let send_options = TaskSendOptions::builder().countdown(10).build();
-            my_app.send_task_with(add::s(1, 3), &send_options).await?;
+            my_app.send_task_with(add::new(1, 3), &send_options).await?;
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! async fn main() -> Result<(), exitfailure::ExitFailure> {
 //!     env_logger::init();
 //!
-//!     my_app.send_task(add::s(1, 2)).await?;
+//!     my_app.send_task(add::new(1, 2)).await?;
 //!
 //!     Ok(())
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! async fn main() -> Result<(), exitfailure::ExitFailure> {
 //!     env_logger::init();
 //!
-//!     my_app.send_task(add(1, 2)).await?;
+//!     my_app.send_task(add::s(1, 2)).await?;
 //!
 //!     Ok(())
 //! }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -44,8 +44,10 @@ use crate::error::Error;
 ///     }
 /// }
 ///
-/// fn add(x: i32, y: i32) -> add {
-///     add { x, y }
+/// impl add {
+///     fn s(x: i32, y: i32) -> Self {
+///         Self { x, y }
+///     }
 /// }
 /// ```
 ///

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -45,7 +45,7 @@ use crate::error::Error;
 /// }
 ///
 /// impl add {
-///     fn s(x: i32, y: i32) -> Self {
+///     fn new(x: i32, y: i32) -> Self {
 ///         Self { x, y }
 ///     }
 /// }

--- a/tests/brokers/amqp.rs
+++ b/tests/brokers/amqp.rs
@@ -39,7 +39,7 @@ impl Task for add {
 }
 
 impl add {
-    fn s(x: i32, y: i32) -> Self {
+    fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
 }
@@ -53,7 +53,7 @@ celery_app!(
 #[tokio::test]
 async fn test_rust_to_rust() {
     // Send task to queue.
-    let send_result = my_app.send_task(add::s(1, 2)).await;
+    let send_result = my_app.send_task(add::new(1, 2)).await;
     assert!(send_result.is_ok());
     let correlation_id = send_result.unwrap();
 

--- a/tests/brokers/amqp.rs
+++ b/tests/brokers/amqp.rs
@@ -38,8 +38,10 @@ impl Task for add {
     }
 }
 
-fn add(x: i32, y: i32) -> add {
-    add { x, y }
+impl add {
+    fn s(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
 }
 
 celery_app!(
@@ -51,7 +53,7 @@ celery_app!(
 #[tokio::test]
 async fn test_rust_to_rust() {
     // Send task to queue.
-    let send_result = my_app.send_task(add(1, 2)).await;
+    let send_result = my_app.send_task(add::s(1, 2)).await;
     assert!(send_result.is_ok());
     let correlation_id = send_result.unwrap();
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -37,7 +37,7 @@ fn task_with_options() -> String {
 
 #[test]
 fn test_task_options() {
-    let t = task_with_options();
+    let t = task_with_options::s();
     assert_eq!(t.timeout(), Some(2));
     assert_eq!(t.max_retries(), Some(3));
     assert_eq!(t.min_retry_delay(), Some(0));
@@ -63,7 +63,7 @@ fn task_with_strings(s1: String, s2: String) -> String {
 
 #[test]
 fn test_task_with_strings() {
-    let t = task_with_strings("hi".into(), "there".into());
+    let t = task_with_strings::s("hi".into(), "there".into());
     let result = futures::executor::block_on(t.run()).unwrap();
     assert_eq!(result, "hi, there");
 }

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -37,7 +37,7 @@ fn task_with_options() -> String {
 
 #[test]
 fn test_task_options() {
-    let t = task_with_options::s();
+    let t = task_with_options::new();
     assert_eq!(t.timeout(), Some(2));
     assert_eq!(t.max_retries(), Some(3));
     assert_eq!(t.min_retry_delay(), Some(0));
@@ -63,7 +63,7 @@ fn task_with_strings(s1: String, s2: String) -> String {
 
 #[test]
 fn test_task_with_strings() {
-    let t = task_with_strings::s("hi".into(), "there".into());
+    let t = task_with_strings::new("hi".into(), "there".into());
     let result = futures::executor::block_on(t.run()).unwrap();
     assert_eq!(result, "hi, there");
 }


### PR DESCRIPTION
Replaces `add(1, 2)` with `add::new(1, 2)`