### PR TITLE
Support acks_late configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Cargo.lock
 __pycache__
 .pytest_cache
 .mypy_cache
+
+# IDE-specific
+.idea/

--- a/celery-codegen/src/lib.rs
+++ b/celery-codegen/src/lib.rs
@@ -15,6 +15,7 @@ mod task;
 /// - `max_retries`: Corresponds to [`Task::max_retries`](trait.Task.html#method.max_retries).
 /// - `min_retry_delay`: Corresponds to [`Task::min_retry_delay`](trait.Task.html#method.min_retry_delay).
 /// - `max_retry_delay`: Corresponds to [`Task::max_retry_delay`](trait.Task.html#method.max_retry_delay).
+/// - `acks_late`: Corresponds to [`Task::acks_late`](trait.Task.html#method.acks_late).
 #[proc_macro_attribute]
 pub fn task(args: TokenStream, input: TokenStream) -> TokenStream {
     task::impl_macro(args, input)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -51,6 +51,7 @@ where
                     max_retries: None,
                     min_retry_delay: 0,
                     max_retry_delay: 3600,
+                    acks_late: false,
                 },
                 task_routes: vec![],
             },
@@ -99,6 +100,12 @@ where
         self
     }
 
+    /// Set whether by default a task is acknowledged before or after execution.
+    pub fn acks_late(mut self, acks_late: bool) -> Self {
+        self.config.task_options.acks_late = acks_late;
+        self
+    }
+
     /// Add a routing rule.
     pub fn task_route(mut self, rule: Rule) -> Self {
         self.config.task_routes.push(rule);
@@ -129,7 +136,7 @@ where
     }
 }
 
-/// A `Celery` app is used to produce or consume tasks asyncronously.
+/// A `Celery` app is used to produce or consume tasks asynchronously.
 pub struct Celery<B: Broker> {
     /// An arbitrary, human-readable name for the app.
     pub name: String,
@@ -229,7 +236,7 @@ where
             Err(e) => {
                 // This is a naughty message that we can't handle, so we'll ack it with
                 // the broker so it gets deleted.
-                self.broker.ack(delivery).await?;
+                self.broker.ack(&delivery).await?;
                 return Err(e);
             }
         };
@@ -243,7 +250,7 @@ where
                 // Even though the message meta data was okay, we failed to deserialize
                 // the body of the message for some reason, so ack it with the broker
                 // to delete it and return an error.
-                self.broker.ack(delivery).await?;
+                self.broker.ack(&delivery).await?;
                 return Err(e);
             }
         };
@@ -257,29 +264,37 @@ where
                 // Otherwise we could reach the prefetch_count and end up blocking
                 // other deliveries if there are a high number of messages with a
                 // future ETA.
-                self.broker.retry(delivery, None).await?;
+                self.broker.ack(&delivery).await?;
+                self.broker.retry(&delivery, None).await?;
                 return Err(e);
             };
+        }
+
+        // If acks_late is false, we acknowledge the message before tracing it.
+        if !self.task_options.acks_late {
+            self.broker.ack(&delivery).await?;
         }
 
         // Try tracing the task now.
         // NOTE: we don't need to log errors from the trace here since the tracer
         // handles all errors at it's own level or the task level. In this function
         // we only log errors at the broker and delivery level.
-        match tracer.trace().await {
-            Ok(_) => {
-                self.broker.ack(delivery).await?;
-            }
-            Err(e) => match e.kind() {
+        if let Err(e) = tracer.trace().await {
+            match e.kind() {
                 // Retriable error -> retry the task.
                 ErrorKind::Retry => {
                     let retry_eta = tracer.retry_eta();
-                    self.broker.retry(delivery, retry_eta).await?
+                    self.broker.retry(&delivery, retry_eta).await?
                 }
-                // Some other kind of error -> ack / delete the task.
-                _ => self.broker.ack(delivery).await?,
-            },
-        };
+                // Some other kind of error -> ignore it.
+                _ => (),
+            }
+        }
+
+        // If we have not done it before, we have to acknowledge the message now.
+        if self.task_options.acks_late {
+            self.broker.ack(&delivery).await?;
+        }
 
         // If we had increased the prefetch count above due to a future ETA, we have
         // to decrease it back down to restore balance to the universe.

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -230,6 +230,10 @@ where
     fn is_expired(&self) -> bool {
         self.message.is_expired()
     }
+
+    fn get_task_options(&self) -> &TaskOptions {
+        &self.options
+    }
 }
 
 #[async_trait]
@@ -244,6 +248,8 @@ pub(super) trait TracerTrait: Send {
     fn is_delayed(&self) -> bool;
 
     fn is_expired(&self) -> bool;
+
+    fn get_task_options(&self) -> &TaskOptions;
 }
 
 pub(super) type TraceBuilderResult = Result<Box<dyn TracerTrait>, Error>;

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -157,7 +157,7 @@ impl Broker for AMQPBroker {
             .map_err(|e| e.into())
     }
 
-    async fn ack(&self, delivery: Self::Delivery) -> Result<(), Error> {
+    async fn ack(&self, delivery: &Self::Delivery) -> Result<(), Error> {
         self.channel
             .basic_ack(delivery.delivery_tag, BasicAckOptions::default())
             .await
@@ -166,7 +166,7 @@ impl Broker for AMQPBroker {
 
     async fn retry(
         &self,
-        delivery: Self::Delivery,
+        delivery: &Self::Delivery,
         eta: Option<DateTime<Utc>>,
     ) -> Result<(), Error> {
         let mut message = delivery.try_into_message()?;
@@ -177,8 +177,7 @@ impl Broker for AMQPBroker {
         if let Some(dt) = eta {
             message.headers.eta = Some(dt);
         };
-        self.send(&message, delivery.routing_key.as_str()).await?;
-        self.ack(delivery).await
+        self.send(&message, delivery.routing_key.as_str()).await
     }
 
     async fn send(&self, message: &Message, queue: &str) -> Result<(), Error> {

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -40,12 +40,12 @@ pub trait Broker: Send + Sync + Sized {
     ) -> Result<Self::DeliveryStream, Error>;
 
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.
-    async fn ack(&self, delivery: Self::Delivery) -> Result<(), Error>;
+    async fn ack(&self, delivery: &Self::Delivery) -> Result<(), Error>;
 
     /// Retry a delivery.
     async fn retry(
         &self,
-        delivery: Self::Delivery,
+        delivery: &Self::Delivery,
         eta: Option<DateTime<Utc>>,
     ) -> Result<(), Error>;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -56,6 +56,12 @@ pub trait Task: Send + Sync + Serialize + for<'de> Deserialize<'de> {
     fn max_retry_delay(&self) -> Option<u32> {
         None
     }
+
+    /// Whether messages for this task will be acknowledged after the task has been executed,
+    /// or before (the default behavior).
+    fn acks_late(&self) -> Option<bool> {
+        None
+    }
 }
 
 /// Additional context sent to the `on_success` and `on_failure` task callbacks.

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -8,6 +8,7 @@ pub struct TaskOptions {
     pub max_retries: Option<u32>,
     pub min_retry_delay: u32,
     pub max_retry_delay: u32,
+    pub acks_late: bool,
 }
 
 impl TaskOptions {
@@ -17,6 +18,7 @@ impl TaskOptions {
             max_retries: task.max_retries().or(self.max_retries),
             min_retry_delay: task.min_retry_delay().unwrap_or(self.min_retry_delay),
             max_retry_delay: task.max_retry_delay().unwrap_or(self.max_retry_delay),
+            acks_late: task.acks_late().unwrap_or(self.acks_late),
         }
     }
 }

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -29,7 +29,8 @@ fn test_auto_name() {
     timeout = 2,
     max_retries = 3,
     min_retry_delay = 0,
-    max_retry_delay = 60
+    max_retry_delay = 60,
+    acks_late = true
 )]
 fn task_with_options() -> String {
     "it worked!".into()
@@ -42,6 +43,7 @@ fn test_task_options() {
     assert_eq!(t.max_retries(), Some(3));
     assert_eq!(t.min_retry_delay(), Some(0));
     assert_eq!(t.max_retry_delay(), Some(60));
+    assert_eq!(t.acks_late(), Some(true));
 }
 
 // This didn't work before since Task::run took a reference to self


### PR DESCRIPTION
List of changes:
- `acks_late` has been added to `TaskOptions`. The default is `false` as per https://docs.celeryproject.org/en/latest/userguide/tasks.html#Task.acks_late.
- `retry` does not `ack`.
- `retry` and `ack` take `delivery` by reference instead of move (since in some cases we have to call both).
- `acks_late` has been added as parameter for the `task` macro.

Comments:
1. I believe that checking `self.task_options.acks_late` (as I do now) **is not taking into account task-specific settings** (see `app/mod.rs` line 274). I think I have to use `tracer` instead. Should I add a `acks_late` method on it, or similar?
2. I have no experience with macros, commit `331d3c2` is a copy-paste of what was already working for the other parameters, I hope I got it right.
3. Let me know if you'd like to add a specific test for this feature.

Closes https://github.com/rusty-celery/rusty-celery/issues/62