### PR TITLE
breaking changes to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Several error enums: `CeleryError`, `TaskError`, `BrokerError`, `ProtocolError`.
+
+### Changed
+
+- The `error` module.
+- The structure of the public API is now more compact. We expose a few more modules, including `broker`, `task`, and `error` instead of exporting all of the public elements from the crate root.
+- The `app` macro (previously `celery_app`) no longer takes an actual broker type (like `AMQPBroker`) for the `broker` parameter. Instead you can just use the literal token `AMQP`. This means one less import for the user.
+
+### Removed
+
+- The `Error` type.
+- The `celery_app` macro has been renamed to just `app`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Several error enums: `CeleryError`, `TaskError`, `BrokerError`, `ProtocolError`.
+- `TaskResultExt` for easily converting the error type in a `Result` to a `TaskError` variant.
 
 ### Changed
 
@@ -20,3 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Error` type.
 - The `celery_app` macro has been renamed to just `app`.
+- The `ResultExt` re-export.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ async-trait = "0.1"
 lapin = { version = "0.28.3", features = ["default", "futures"] }
 amq-protocol = "3.1"
 log = "0.4"
-env_logger = "0.7"
 futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}
 rand = "0.7"
@@ -42,6 +41,7 @@ globset = "0.4"
 cookie-factory = "0.3.1"
 
 [dev-dependencies]
+env_logger = "0.7"
 exitfailure = "0.5.1"
 structopt = "0.3"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "celery-codegen"]
 
 [package]
 name = "celery"
-version = "0.1.1"
+version = "0.2.0-dev"
 authors = ["epwalsh <epwalsh10@gmail.com>"]
 edition = "2018"
 keywords = ["celery", "amqp", "rabbitmq", "background-jobs"]
@@ -34,7 +34,7 @@ env_logger = "0.7"
 futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}
 rand = "0.7"
-celery-codegen = { version = "0.1.1", path = "./celery-codegen", optional = true }
+celery-codegen = { version = "0.2.0-dev", path = "./celery-codegen", optional = true }
 once_cell = { version = "1.3.1", optional = true }
 globset = "0.4"
 # This is only used by amqp-protocol. We need to pin to this version to avoid a compilation error

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ If you already know the basics of Rust, the [Rusty Celery Book](https://rusty-ce
 Define tasks by decorating functions with the [`task`](https://docs.rs/celery/*/celery/attr.task.html) attribute.
 
 ```rust
-#[task]
+#[celery::task]
 fn add(x: i32, y: i32) -> i32 {
     x + y
 }
 ```
 
-Create an app with the [`celery_app`](https://docs.rs/celery/*/celery/macro.celery_app.html) macro
+Create an app with the [`app`](https://docs.rs/celery/*/celery/macro.celery_app.html) macro
 and register your tasks with it:
 
 ```rust
-let my_app = celery_app!(
-    broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+let my_app = celery::app!(
+    broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
     tasks = [add],
     task_routes = [
         "*" => "celery",

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,7 +1,8 @@
 # Publishing a new release
 
 1. Change the version in all subcrate `Cargo.toml` files and in the root `Cargo.toml`. Also change the version of the subcrate dependencies in the root `Cargo.toml`. All versions should now match.
-2. Commit these changes with the message `(cargo-release) version VERSION`.
-3. Add a tag in git to mark the release: `git tag VERSION -m 'Adds tag VERSION for cargo'`.
-4. Push the tag to git: `git push --tags origin master`.
-5. For each subcrate and the root crate, build and publish to [crates.io](crates.io) by running `cargo publish` within the corresponding directory.
+2. Update the [CHANGELOG]("CHANGELOG.md").
+3. Commit these changes with the message `(cargo-release) version VERSION`.
+4. Add a tag in git to mark the release: `git tag VERSION -m 'Adds tag VERSION for cargo'`.
+5. Push the tag to git: `git push --tags origin master`.
+6. For each subcrate and the root crate, build and publish to [crates.io](crates.io) by running `cargo publish` within the corresponding directory.

--- a/celery-codegen/Cargo.toml
+++ b/celery-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celery-codegen"
-version = "0.1.1"
+version = "0.2.0-dev"
 authors = ["epwalsh <epwalsh10@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/celery-codegen/src/lib.rs
+++ b/celery-codegen/src/lib.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 mod error;
 mod task;
 
-/// A procedural macro for generating a [`Task`](trait.Task.html) from a function.
+/// A procedural macro for generating a [`Task`](task/trait.Task.html) from a function.
 ///
 /// # Parameters
 ///

--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -394,7 +394,7 @@ impl ToTokens for Task {
                 use #export::async_trait;
 
                 #[async_trait]
-                impl #krate::Task for #wrapper {
+                impl #krate::task::Task for #wrapper {
                     const NAME: &'static str = #task_name;
                     const ARGS: &'static [&'static str] = &[#arg_names];
 

--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -394,13 +394,13 @@ impl ToTokens for Task {
                 use #export::async_trait;
 
                 #[async_trait]
-                impl #krate::Task for #wrapper {
+                impl #krate::task::Task for #wrapper {
                     const NAME: &'static str = #task_name;
                     const ARGS: &'static [&'static str] = &[#arg_names];
 
                     type Returns = #ret_ty;
 
-                    async fn run(mut self) -> Result<Self::Returns, #krate::Error> {
+                    async fn run(mut self) -> Result<Self::Returns, #krate::error::TaskError> {
                         #deserialized_bindings
                         Ok(#inner_block)
                     }

--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -394,7 +394,7 @@ impl ToTokens for Task {
                 use #export::async_trait;
 
                 #[async_trait]
-                impl #krate::task::Task for #wrapper {
+                impl #krate::Task for #wrapper {
                     const NAME: &'static str = #task_name;
                     const ARGS: &'static [&'static str] = &[#arg_names];
 

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use celery::error::TaskError;
-use celery::TaskSendOptions;
+use celery::task::TaskSendOptions;
 use env_logger::Env;
 use exitfailure::ExitFailure;
 use structopt::StructOpt;

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use celery::error::TaskError;
-use celery::task::TaskSendOptions;
+use celery::TaskSendOptions;
 use env_logger::Env;
 use exitfailure::ExitFailure;
 use structopt::StructOpt;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -192,9 +192,6 @@ where
         Ok(Celery {
             name: self.config.name,
             broker: broker.ok_or_else(|| BrokerError::NotConnected)?,
-            broker_connection_timeout: self.config.broker_connection_timeout,
-            broker_connection_retry: self.config.broker_connection_retry,
-            broker_connection_max_retries: self.config.broker_connection_max_retries,
             default_queue: self.config.default_queue,
             task_options: self.config.task_options,
             task_routes: self.config.task_routes,
@@ -210,24 +207,13 @@ pub struct Celery<B: Broker> {
     pub name: String,
 
     /// The app's broker.
-    pub broker: B,
-
-    /// A timeout in seconds to wait before giving up trying to establish a connection
-    /// to the broker.
-    pub broker_connection_timeout: u32,
-
-    /// Automatically try to re-establish connection to the AMQP broker.
-    pub broker_connection_retry: bool,
-
-    /// Maximum number of retries before we give up trying to re-establish connection
-    /// to the AMQP broker.
-    pub broker_connection_max_retries: u32,
+    broker: B,
 
     /// The default queue to send and receive from.
-    pub default_queue: String,
+    default_queue: String,
 
     /// Default task options.
-    pub task_options: TaskOptions,
+    task_options: TaskOptions,
 
     /// A vector of routing rules in the order of their importance.
     task_routes: Vec<Rule>,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+use failure::Fail;
 use futures::stream::{select_all, StreamExt};
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
@@ -11,7 +12,7 @@ mod routing;
 mod trace;
 
 use crate::broker::{Broker, BrokerBuilder};
-use crate::error::{Error, ErrorKind};
+use crate::error::{BrokerError, CeleryError, TaskError};
 use crate::protocol::{Message, TryIntoMessage};
 use crate::task::{Task, TaskEvent, TaskOptions, TaskSendOptions, TaskStatus};
 pub use routing::Rule;
@@ -139,7 +140,7 @@ where
     }
 
     /// Construct a `Celery` app with the current configuration.
-    pub async fn build(self) -> Result<Celery<Bb::Broker>, Error> {
+    pub async fn build(self) -> Result<Celery<Bb::Broker>, CeleryError> {
         // Declare default queue to broker.
         let mut broker_builder = self
             .config
@@ -164,18 +165,21 @@ where
                 broker_builder.build(),
             )
             .await
-            .map_err(|_| Error::from(ErrorKind::BrokerConnectionError))
+            .map_err(|_| BrokerError::ConnectTimeout)
             .and_then(|res| res)
             {
-                Err(err) => match err.kind() {
-                    ErrorKind::BrokerConnectionError => {
+                Err(err) => match err {
+                    BrokerError::ConnectTimeout
+                    | BrokerError::ConnectionRefused
+                    | BrokerError::IoError
+                    | BrokerError::NotConnected => {
                         if i < max_retries {
                             error!("Failed to establish connection with broker, trying again in 200ms...")
                         }
                         time::delay_for(Duration::from_millis(200)).await;
                         continue;
                     }
-                    _ => return Err(err),
+                    _ => return Err(err.into()),
                 },
                 Ok(b) => {
                     broker = Some(b);
@@ -186,7 +190,7 @@ where
 
         Ok(Celery {
             name: self.config.name,
-            broker: broker.ok_or_else(|| Error::from(ErrorKind::BrokerConnectionError))?,
+            broker: broker.ok_or_else(|| BrokerError::NotConnected)?,
             broker_connection_timeout: self.config.broker_connection_timeout,
             broker_connection_retry: self.config.broker_connection_retry,
             broker_connection_max_retries: self.config.broker_connection_max_retries,
@@ -242,7 +246,7 @@ where
 
     /// Send a task to a remote worker with default options. Returns the correlation ID
     /// of the task if successful.
-    pub async fn send_task<T: Task>(&self, task: T) -> Result<String, Error> {
+    pub async fn send_task<T: Task>(&self, task: T) -> Result<String, CeleryError> {
         let queue = routing::route(T::NAME, &self.task_routes).unwrap_or(&self.default_queue);
         let options = TaskSendOptions::builder().queue(queue).build();
         self.send_task_with(task, &options).await
@@ -254,7 +258,7 @@ where
         &self,
         task: T,
         options: &TaskSendOptions,
-    ) -> Result<String, Error> {
+    ) -> Result<String, CeleryError> {
         let message = Message::builder(task)?.task_send_options(options).build();
         debug!("Sending message {:?}", message);
         let queue = options.queue.as_ref().unwrap_or(&self.default_queue);
@@ -263,13 +267,13 @@ where
     }
 
     /// Register a task.
-    pub fn register_task<T: Task + 'static>(&self) -> Result<(), Error> {
+    pub fn register_task<T: Task + 'static>(&self) -> Result<(), CeleryError> {
         let mut task_trace_builders = self
             .task_trace_builders
             .write()
-            .map_err(|_| Error::from(ErrorKind::SyncError))?;
+            .map_err(|_| CeleryError::SyncError)?;
         if task_trace_builders.contains_key(T::NAME) {
-            Err(ErrorKind::TaskAlreadyExists(T::NAME.into()).into())
+            Err(CeleryError::TaskRegistrationError(T::NAME.into()))
         } else {
             task_trace_builders.insert(T::NAME.into(), Box::new(build_tracer::<T>));
             info!("Registered task {}", T::NAME);
@@ -281,15 +285,16 @@ where
         &self,
         message: Message,
         event_tx: UnboundedSender<TaskEvent>,
-    ) -> Result<Box<dyn TracerTrait>, Error> {
+    ) -> Result<Box<dyn TracerTrait>, Box<dyn Fail>> {
         let task_trace_builders = self
             .task_trace_builders
             .read()
-            .map_err(|_| Error::from(ErrorKind::SyncError))?;
+            .map_err(|_| Box::new(CeleryError::SyncError) as Box<dyn Fail>)?;
         if let Some(build_tracer) = task_trace_builders.get(&message.headers.task) {
-            Ok(build_tracer(message, self.task_options, event_tx)?)
+            Ok(build_tracer(message, self.task_options, event_tx)
+                .map_err(|e| Box::new(e) as Box<dyn Fail>)?)
         } else {
-            Err(ErrorKind::UnregisteredTaskError(message.headers.task).into())
+            Err(Box::new(CeleryError::UnregisteredTaskError(message.headers.task)) as Box<dyn Fail>)
         }
     }
 
@@ -297,20 +302,20 @@ where
     /// and communicating with the broker.
     async fn try_handle_delivery(
         &self,
-        delivery_result: Result<B::Delivery, B::DeliveryError>,
+        delivery: B::Delivery,
         event_tx: UnboundedSender<TaskEvent>,
-    ) -> Result<(), Error> {
-        let delivery = delivery_result.map_err(|e| e.into())?;
-        debug!("Received delivery: {:?}", delivery);
-
+    ) -> Result<(), Box<dyn Fail>> {
         // Coerce the delivery into a protocol message.
         let message = match delivery.try_into_message() {
             Ok(message) => message,
             Err(e) => {
                 // This is a naughty message that we can't handle, so we'll ack it with
                 // the broker so it gets deleted.
-                self.broker.ack(&delivery).await?;
-                return Err(e);
+                self.broker
+                    .ack(&delivery)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
+                return Err(Box::new(e));
             }
         };
 
@@ -323,8 +328,11 @@ where
                 // Even though the message meta data was okay, we failed to deserialize
                 // the body of the message for some reason, so ack it with the broker
                 // to delete it and return an error.
-                self.broker.ack(&delivery).await?;
-                return Err(e);
+                self.broker
+                    .ack(&delivery)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
+                return Err(Box::new(e));
             }
         };
 
@@ -337,15 +345,24 @@ where
                 // Otherwise we could reach the prefetch_count and end up blocking
                 // other deliveries if there are a high number of messages with a
                 // future ETA.
-                self.broker.retry(&delivery, None).await?;
-                self.broker.ack(&delivery).await?;
-                return Err(e);
+                self.broker
+                    .retry(&delivery, None)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
+                self.broker
+                    .ack(&delivery)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
+                return Err(Box::new(e));
             };
         }
 
         // If acks_late is false, we acknowledge the message before tracing it.
         if !tracer.get_task_options().acks_late {
-            self.broker.ack(&delivery).await?;
+            self.broker
+                .ack(&delivery)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
         }
 
         // Try tracing the task now.
@@ -354,21 +371,30 @@ where
         // we only log errors at the broker and delivery level.
         if let Err(e) = tracer.trace().await {
             // If retriable error -> retry the task.
-            if let ErrorKind::Retry = e.kind() {
+            if let TaskError::Retry = e {
                 let retry_eta = tracer.retry_eta();
-                self.broker.retry(&delivery, retry_eta).await?
+                self.broker
+                    .retry(&delivery, retry_eta)
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
             }
         }
 
         // If we have not done it before, we have to acknowledge the message now.
         if tracer.get_task_options().acks_late {
-            self.broker.ack(&delivery).await?;
+            self.broker
+                .ack(&delivery)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
         }
 
         // If we had increased the prefetch count above due to a future ETA, we have
         // to decrease it back down to restore balance to the universe.
         if tracer.is_delayed() {
-            self.broker.decrease_prefetch_count().await?;
+            self.broker
+                .decrease_prefetch_count()
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn Fail>)?;
         }
 
         Ok(())
@@ -380,19 +406,27 @@ where
         delivery_result: Result<B::Delivery, B::DeliveryError>,
         event_tx: UnboundedSender<TaskEvent>,
     ) {
-        if let Err(e) = self.try_handle_delivery(delivery_result, event_tx).await {
-            error!("{}", e);
-        }
+        match delivery_result {
+            Ok(delivery) => {
+                debug!("Received delivery: {:?}", delivery);
+                if let Err(e) = self.try_handle_delivery(delivery, event_tx).await {
+                    error!("{}", e);
+                };
+            }
+            Err(e) => {
+                error!("Deliver failed: {}", e);
+            }
+        };
     }
 
     /// Consume tasks from the default queue.
-    pub async fn consume(&'static self) -> Result<(), Error> {
+    pub async fn consume(&'static self) -> Result<(), CeleryError> {
         Ok(self.consume_from(&[&self.default_queue]).await?)
     }
 
     /// Consume tasks from a group of queues.
     #[allow(clippy::cognitive_complexity)]
-    pub async fn consume_from(&'static self, queues: &[&str]) -> Result<(), Error> {
+    pub async fn consume_from(&'static self, queues: &[&str]) -> Result<(), CeleryError> {
         // Stream of errors from broker.
         let (broker_error_tx, mut broker_error_rx) = mpsc::channel::<()>(100);
 
@@ -461,7 +495,7 @@ where
                 maybe_broker_error = broker_error_rx.next() => {
                     if maybe_broker_error.is_some() {
                         error!("Broker lost connection");
-                        return Err(ErrorKind::BrokerConnectionError.into());
+                        return Err(BrokerError::NotConnected.into());
                     }
                 }
             };
@@ -476,7 +510,7 @@ where
                 select! {
                     _ = sigint.next() => {
                         warn!("Okay fine, shutting down now. See ya!");
-                        return Err(ErrorKind::ForcedShutdown.into());
+                        return Err(CeleryError::ForcedShutdown);
                     },
                     maybe_event = task_event_rx.next() => {
                         if let Some(event) = maybe_event {
@@ -500,7 +534,7 @@ where
     }
 
     /// Close channels and connections.
-    pub async fn close(&self) -> Result<(), Error> {
+    pub async fn close(&self) -> Result<(), CeleryError> {
         Ok(self.broker.close().await?)
     }
 }

--- a/src/app/routing.rs
+++ b/src/app/routing.rs
@@ -1,6 +1,6 @@
 use globset::{Glob, GlobMatcher};
 
-use crate::Error;
+use crate::error::CeleryError;
 
 /// A rule for routing tasks to a queue based on a glob pattern.
 pub struct Rule {
@@ -9,7 +9,7 @@ pub struct Rule {
 }
 
 impl Rule {
-    pub fn new(pattern: &str, queue: &str) -> Result<Self, Error> {
+    pub fn new(pattern: &str, queue: &str) -> Result<Self, CeleryError> {
         Ok(Self {
             pattern: Glob::new(pattern)?.compile_matcher(),
             queue: queue.into(),

--- a/src/app/routing.rs
+++ b/src/app/routing.rs
@@ -3,20 +3,20 @@ use globset::{Glob, GlobMatcher};
 use crate::error::CeleryError;
 
 /// A rule for routing tasks to a queue based on a glob pattern.
-pub struct Rule {
-    pub pattern: GlobMatcher,
-    pub queue: String,
+pub(super) struct Rule {
+    pub(super) pattern: GlobMatcher,
+    pub(super) queue: String,
 }
 
 impl Rule {
-    pub fn new(pattern: &str, queue: &str) -> Result<Self, CeleryError> {
+    pub(super) fn new(pattern: &str, queue: &str) -> Result<Self, CeleryError> {
         Ok(Self {
             pattern: Glob::new(pattern)?.compile_matcher(),
             queue: queue.into(),
         })
     }
 
-    pub fn is_match(&self, task_name: &str) -> bool {
+    pub(super) fn is_match(&self, task_name: &str) -> bool {
         self.pattern.is_match(task_name)
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -7,23 +7,22 @@ macro_rules! __app_internal {
         [ $( $pattern:expr => $queue:expr ),* ],
         $( $x:ident = $y:expr, )*
     ) => {{
-        static CELERY_APP: $crate::export::OnceCell<$crate::app::Celery<$broker_type>> =
+        static CELERY_APP: $crate::export::OnceCell<$crate::Celery<$broker_type>> =
             $crate::export::OnceCell::new();
         CELERY_APP.get_or_init(|| {
             let broker_url = $broker_url;
 
-            let mut builder = $crate::app::Celery::<$broker_type>::builder("celery", &broker_url);
+            let mut builder = $crate::Celery::<$broker_type>::builder("celery", &broker_url);
 
             $(
                 builder = builder.$x($y);
             )*
 
             $(
-                let rule = $crate::app::Rule::new($pattern, $queue).unwrap();
-                builder = builder.task_route(rule);
+                builder = builder.task_route($pattern, $queue).unwrap();
             )*
 
-            let celery: $crate::app::Celery<$broker_type> = $crate::export::block_on(builder.build()).unwrap();
+            let celery: $crate::Celery<$broker_type> = $crate::export::block_on(builder.build()).unwrap();
 
             $(
                 celery.register_task::<$t>().unwrap();
@@ -34,7 +33,7 @@ macro_rules! __app_internal {
     }};
 }
 
-/// A macro for creating a `Celery` app.
+/// A macro for creating a [`Celery`](struct.Celery.html) app.
 ///
 /// At a minimum the `app!` macro requires 3 arguments:
 /// - a broker type (currently only AMQP is supported) with an expression for the broker URL in brackets,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,29 +1,29 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __celery_app_internal {
+macro_rules! __app_internal {
     (
         $broker_type:ty { $broker_url:expr },
         [ $( $t:ty ),* ],
         [ $( $pattern:expr => $queue:expr ),* ],
         $( $x:ident = $y:expr, )*
     ) => {{
-        static CELERY_APP: $crate::export::OnceCell<$crate::Celery<$broker_type>> =
+        static CELERY_APP: $crate::export::OnceCell<$crate::app::Celery<$broker_type>> =
             $crate::export::OnceCell::new();
         CELERY_APP.get_or_init(|| {
             let broker_url = $broker_url;
 
-            let mut builder = $crate::Celery::<$broker_type>::builder("celery", &broker_url);
+            let mut builder = $crate::app::Celery::<$broker_type>::builder("celery", &broker_url);
 
             $(
                 builder = builder.$x($y);
             )*
 
             $(
-                let rule = $crate::Rule::new($pattern, $queue).unwrap();
+                let rule = $crate::app::Rule::new($pattern, $queue).unwrap();
                 builder = builder.task_route(rule);
             )*
 
-            let celery: $crate::Celery<$broker_type> = $crate::export::block_on(builder.build()).unwrap();
+            let celery: $crate::app::Celery<$broker_type> = $crate::export::block_on(builder.build()).unwrap();
 
             $(
                 celery.register_task::<$t>().unwrap();
@@ -36,8 +36,8 @@ macro_rules! __celery_app_internal {
 
 /// A macro for creating a `Celery` app.
 ///
-/// At a minimum the `celery_app!` macro requires 3 arguments:
-/// - a broker type with an expression for the broker URL in brackets,
+/// At a minimum the `app!` macro requires 3 arguments:
+/// - a broker type (currently only AMQP is supported) with an expression for the broker URL in brackets,
 /// - a list of tasks to register, and
 /// - a list of routing rules in the form of `pattern => queue`.
 ///
@@ -45,16 +45,14 @@ macro_rules! __celery_app_internal {
 ///
 /// ```rust,no_run
 /// # #[macro_use] extern crate celery;
-/// use celery::{celery_app, task, AMQPBroker};
-///
-/// #[task]
+/// #[celery::task]
 /// fn add(x: i32, y: i32) -> i32 {
 ///     x + y
 /// }
 ///
 /// # fn main() {
-/// let app = celery_app!(
-///     broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+/// let app = celery::app!(
+///     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 ///     tasks = [ add ],
 ///     task_routes = [ "*" => "celery" ],
 /// );
@@ -67,10 +65,9 @@ macro_rules! __celery_app_internal {
 ///
 /// ```rust,no_run
 /// # #[macro_use] extern crate celery;
-/// # use celery::{celery_app, AMQPBroker};
 /// # fn main() {
-/// let app = celery_app!(
-///     broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+/// let app = celery::app!(
+///     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 ///     tasks = [],
 ///     task_routes = [],
 ///     task_timeout = 2,
@@ -78,41 +75,41 @@ macro_rules! __celery_app_internal {
 /// # }
 /// ```
 #[macro_export]
-macro_rules! celery_app {
+macro_rules! app {
     (
-        broker = $broker_type:ty { $broker_url:expr },
+        broker = AMQP { $broker_url:expr },
         tasks = [ $( $t:ty ),* $(,)? ],
         task_routes = [ $( $pattern:expr => $queue:expr ),* $(,)? ],
         $( $x:ident = $y:expr, )*
     ) => {
-        $crate::__celery_app_internal!(
-            $broker_type { $broker_url },
+        $crate::__app_internal!(
+            $crate::broker::AMQPBroker { $broker_url },
             [ $( $t ),* ],
             [ $( $pattern => $queue ),* ],
             $( $x = $y, )*
         );
     };
     (
-        broker = $broker_type:ty { $broker_url:expr },
+        broker = AMQP { $broker_url:expr },
         tasks = [ $( $t:ty ),* $(,)? ],
         task_routes = [ $( $pattern:expr => $queue:expr ),* $(,)? ],
         $( $x:ident = $y:expr, )*
     ) => {
-        $crate::__celery_app_internal!(
-            $broker_type { $broker_url },
+        $crate::__app_internal!(
+            $crate::broker::AMQPBroker { $broker_url },
             [ $( $t ),* ],
             [ $( $pattern => $queue ),* ],
             $( $x = $y, )*
         );
     };
     (
-        broker = $broker_type:ty { $broker_url:expr },
+        broker = AMQP { $broker_url:expr },
         tasks = [ $( $t:ty ),* $(,)? ],
         task_routes = [ $( $pattern:expr => $queue:expr ),* $(,)? ],
         $( $x:ident = $y:expr, )*
     ) => {
-        $crate::__celery_app_internal!(
-            $broker_type { $broker_url },
+        $crate::__app_internal!(
+            $crate::broker::AMQPBroker { $broker_url },
             [ $( $t ),* ],
             [ $( $pattern => $queue ),* ],
             $( $x = $y, )*

--- a/src/error.rs
+++ b/src/error.rs
@@ -175,20 +175,21 @@ impl From<Context<&str>> for TaskError {
 /// [`failure::Fail`](https://docs.rs/failure/0.1.6/failure/trait.Fail.html).
 pub trait TaskResultExt<T, E> {
     /// Convert the error type to a `TaskError::ExpectedError`.
-    fn as_expected_err(self, context: &str) -> Result<T, TaskError>;
+    fn with_expected_err(self, context: &str) -> Result<T, TaskError>;
 
     /// Convert the error type to a `TaskError::UnexpectedError`.
-    fn as_unexpected_err(self, context: &str) -> Result<T, TaskError>;
+    fn with_unexpected_err(self, context: &str) -> Result<T, TaskError>;
 }
 
 impl<T, E> TaskResultExt<T, E> for Result<T, E>
 where
     E: Fail,
 {
-    fn as_expected_err(self, context: &str) -> Result<T, TaskError> {
+    fn with_expected_err(self, context: &str) -> Result<T, TaskError> {
         self.map_err(|_failure| TaskError::ExpectedError(context.into()))
     }
-    fn as_unexpected_err(self, context: &str) -> Result<T, TaskError> {
+
+    fn with_unexpected_err(self, context: &str) -> Result<T, TaskError> {
         self.map_err(|_failure| TaskError::UnexpectedError(context.into()))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use failure::Fail;
+use failure::{Context, Fail};
 
 /// Errors that can occur while creating or using a `Celery` app.
 #[derive(Debug, Fail)]
@@ -158,5 +158,11 @@ impl From<lapin::Error> for BrokerError {
             lapin::Error::ConnectionRefused => BrokerError::ConnectionRefused,
             _ => BrokerError::AMQPError(err),
         }
+    }
+}
+
+impl From<Context<&str>> for TaskError {
+    fn from(ctx: Context<&str>) -> Self {
+        Self::UnexpectedError((*ctx.get_context()).into())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,44 +1,47 @@
-use std::fmt;
+use failure::Fail;
 
-use failure::{Backtrace, Context, Fail};
-
-/// Any error that can occur while using `celery`.
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-/// Error kinds that can occur while using `celery`.
+/// Errors that can occur while creating or using a `Celery` app.
 #[derive(Debug, Fail)]
-pub enum ErrorKind {
-    /// You tried to register a task but a task by that name already exists.
-    #[fail(display = "Task named '{}' already exists", _0)]
-    TaskAlreadyExists(String),
-
-    /// Received an unregistered task.
-    #[fail(display = "Received unregistered task named '{}'", _0)]
-    UnregisteredTaskError(String),
-
-    /// An AMQP broker error.
-    #[fail(display = "AMQP error: {:?}", _0)]
-    AMQPError(Option<lapin::Error>),
-
-    /// Raised when broker URL can't be parsed.
-    #[fail(display = "Broker URL is invalid: {}", _0)]
-    InvalidBrokerUrl(String),
-
-    /// An error occured while serializing or deserializing.
-    #[fail(display = "Serialization error: {}", _0)]
-    SerializationError(serde_json::Error),
-
-    /// A consumed delivery was in an unknown format.
-    #[fail(display = "Failed to parse message: ({})", _0)]
-    AMQPMessageParseError(String),
-
+pub enum CeleryError {
     /// The queue you're attempting to use has not been defined.
     #[fail(display = "Unknown queue '{}'", _0)]
-    UnknownQueueError(String),
+    UnknownQueue(String),
 
+    /// When a mutex is poisened, for example.
+    #[fail(display = "Sync error")]
+    SyncError,
+
+    /// Forced shutdown.
+    #[fail(display = "Forced shutdown")]
+    ForcedShutdown,
+
+    /// Any other broker-level error that could happen when initializing.
+    #[fail(display = "{}", _0)]
+    BrokerError(#[fail(cause)] BrokerError),
+
+    /// Any other IO error that could occur.
+    #[fail(display = "{}", _0)]
+    IoError(#[fail(cause)] std::io::Error),
+
+    /// A protocol error.
+    #[fail(display = "Protocol error: {}", _0)]
+    ProtocolError(#[fail(cause)] ProtocolError),
+
+    /// An invalid glob pattern for a routing rule.
+    #[fail(display = "Invalid glob routing rule '{}'", _0)]
+    BadRoutingPattern(#[fail(cause)] globset::Error),
+
+    /// There is already a task registerd to this name.
+    #[fail(display = "There is already a task registered as '{}'", _0)]
+    TaskRegistrationError(String),
+
+    #[fail(display = "Received unregistered task {}", _0)]
+    UnregisteredTaskError(String),
+}
+
+/// Errors that can occur while running or tracing a task.
+#[derive(Debug, Fail)]
+pub enum TaskError {
     /// An error that is expected to happen every once in a while and should trigger
     /// the task to be retried without causes a fit.
     #[fail(display = "{}", _0)]
@@ -48,129 +51,112 @@ pub enum ErrorKind {
     #[fail(display = "{}", _0)]
     UnexpectedError(String),
 
-    /// Should be used when an expired task is received.
+    /// Raised when an expired task is received.
     #[fail(display = "Task expired")]
-    TaskExpiredError,
+    ExpirationError,
 
-    /// Raise when a task should be retried.
+    /// Raised when a task should be retried.
     #[fail(display = "Retrying task")]
     Retry,
+
+    /// Raised when a task runs over its time limit.
+    #[fail(display = "Task timed out")]
+    TimeoutError,
+}
+
+/// Errors that can occur at the broker level.
+#[derive(Debug, Fail)]
+pub enum BrokerError {
+    /// Raised when a broker URL can't be parsed.
+    #[fail(display = "Invalid broker URL: {}", _0)]
+    InvalidBrokerUrl(String),
+
+    /// The queue you're attempting to use has not been defined.
+    #[fail(display = "Unknown queue '{}'", _0)]
+    UnknownQueue(String),
 
     /// When a mutex is poisened, for example.
     #[fail(display = "Sync error")]
     SyncError,
 
-    /// An IO error.
-    #[fail(display = "An IO error occured ({:?})", _0)]
-    IoError(tokio::io::ErrorKind),
+    /// Broker is disconnected.
+    #[fail(display = "Broker not connected")]
+    NotConnected,
 
-    /// Forced shutdown.
-    #[fail(display = "Forced shutdown")]
-    ForcedShutdown,
+    /// Connection request timed-out.
+    #[fail(display = "Connection request timed-out.")]
+    ConnectTimeout,
 
-    /// Task timed out.
-    #[fail(display = "Task timed out")]
-    TimeoutError,
+    /// Broker connection refused.
+    #[fail(display = "Broker connection refused")]
+    ConnectionRefused,
 
-    /// Invalid routing glob pattern.
-    #[fail(display = "Bad routing rule pattern: {:?}", _0)]
-    BadRoutingRulePatternError(Option<String>),
+    /// Broker IO error.
+    #[fail(display = "Broker IO error")]
+    IoError,
 
-    /// Broker connection failed.
-    #[fail(display = "Broker connection error")]
-    BrokerConnectionError,
+    /// Any other AMQP error that could happen.
+    #[fail(display = "{}", _0)]
+    AMQPError(#[fail(cause)] lapin::Error),
 }
 
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
+/// Errors that can occur due to messages not conforming to the protocol.
+#[derive(Debug, Fail)]
+pub enum ProtocolError {
+    /// Raised when a required message property is missing.
+    #[fail(display = "Missing required property '{}'", _0)]
+    MissingRequiredProperty(String),
 
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
+    /// Raised when the headers are missing altogether.
+    #[fail(display = "Missing headers")]
+    MissingHeaders,
+
+    /// Raised when a required message header is missing.
+    #[fail(display = "Missing required property '{}'", _0)]
+    MissingRequiredHeader(String),
+
+    /// Raised when serializing or de-serializing a message body fails.
+    #[fail(display = "{}", _0)]
+    BodySerializationError(#[fail(cause)] serde_json::Error),
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
-    }
-}
-
-impl Error {
-    /// Get the inner `ErrorKind`.
-    pub fn kind(&self) -> &ErrorKind {
-        self.inner.get_context()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
-        }
+impl From<BrokerError> for CeleryError {
+    fn from(err: BrokerError) -> Self {
+        Self::BrokerError(err)
     }
 }
 
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
+impl From<ProtocolError> for CeleryError {
+    fn from(err: ProtocolError) -> Self {
+        Self::ProtocolError(err)
     }
 }
 
-impl From<Context<&str>> for Error {
-    fn from(inner: Context<&str>) -> Error {
-        Error {
-            inner: Context::new(ErrorKind::UnexpectedError(
-                (*inner.get_context()).to_string(),
-            )),
-        }
+impl From<std::io::Error> for CeleryError {
+    fn from(err: std::io::Error) -> Self {
+        Self::IoError(err)
     }
 }
 
-impl From<lapin::Error> for Error {
-    fn from(err: lapin::Error) -> Error {
-        Error {
-            inner: Context::new(match err {
-                lapin::Error::NotConnected => ErrorKind::BrokerConnectionError,
-                lapin::Error::ConnectionRefused => ErrorKind::BrokerConnectionError,
-                lapin::Error::IOError(_) => ErrorKind::BrokerConnectionError,
-                _ => ErrorKind::AMQPError(Some(err)),
-            }),
-        }
+impl From<globset::Error> for CeleryError {
+    fn from(err: globset::Error) -> Self {
+        Self::BadRoutingPattern(err)
     }
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Error {
-        Error {
-            inner: Context::new(ErrorKind::SerializationError(err)),
-        }
+impl From<serde_json::Error> for ProtocolError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::BodySerializationError(err)
     }
 }
 
-impl From<tokio::io::Error> for Error {
-    fn from(err: tokio::io::Error) -> Error {
-        Error {
-            inner: Context::new(ErrorKind::IoError(err.kind())),
-        }
-    }
-}
-
-impl From<tokio::time::Elapsed> for Error {
-    fn from(_err: tokio::time::Elapsed) -> Error {
-        Error {
-            inner: Context::new(ErrorKind::TimeoutError),
-        }
-    }
-}
-
-impl From<globset::Error> for Error {
-    fn from(_err: globset::Error) -> Error {
-        Error {
-            inner: Context::new(ErrorKind::BadRoutingRulePatternError(
-                _err.glob().map(|s| s.into()),
-            )),
+impl From<lapin::Error> for BrokerError {
+    fn from(err: lapin::Error) -> Self {
+        match err {
+            lapin::Error::NotConnected => BrokerError::NotConnected,
+            lapin::Error::IOError(_) => BrokerError::IoError,
+            lapin::Error::ConnectionRefused => BrokerError::ConnectionRefused,
+            _ => BrokerError::AMQPError(err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,3 +166,29 @@ impl From<Context<&str>> for TaskError {
         Self::UnexpectedError((*ctx.get_context()).into())
     }
 }
+
+/// Extension methods for `Result` types within a task body.
+///
+/// These methods can be used to convert any `Result` to the appropriate `TaskError` variant. The
+/// trait has a blanket implementation for any error type that implements
+/// [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html) or
+/// [`failure::Fail`](https://docs.rs/failure/0.1.6/failure/trait.Fail.html).
+pub trait TaskResultExt<T, E> {
+    /// Convert the error type to a `TaskError::ExpectedError`.
+    fn as_expected_err(self, context: &str) -> Result<T, TaskError>;
+
+    /// Convert the error type to a `TaskError::UnexpectedError`.
+    fn as_unexpected_err(self, context: &str) -> Result<T, TaskError>;
+}
+
+impl<T, E> TaskResultExt<T, E> for Result<T, E>
+where
+    E: Fail,
+{
+    fn as_expected_err(self, context: &str) -> Result<T, TaskError> {
+        self.map_err(|_failure| TaskError::ExpectedError(context.into()))
+    }
+    fn as_unexpected_err(self, context: &str) -> Result<T, TaskError> {
+        self.map_err(|_failure| TaskError::UnexpectedError(context.into()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,14 +121,13 @@ pub mod export;
 pub mod protocol;
 
 /// Provides the `Task` trait as well as options for configuring tasks.
-mod task;
+pub mod task;
 
 /////////////////
 // Public API. //
 /////////////////
 
 pub use app::{Celery, CeleryBuilder};
-pub use task::{Task, TaskContext, TaskOptions, TaskSendOptions};
 
 #[cfg(feature = "codegen")]
 pub use celery_codegen::task;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! }
 //! ```
 //!
-//! Then create a [`Celery`](struct.Celery.html) app with the [`celery_app`](macro.celery_app.html)
+//! Then create a [`Celery`](struct.Celery.html) app with the [`app`](macro.app.html)
 //! macro and register your tasks with it:
 //!
 //! ```rust,no_run
@@ -93,37 +93,42 @@ extern crate async_trait;
 #[cfg(feature = "codegen")]
 extern crate serde;
 
-#[cfg(feature = "codegen")]
-pub use celery_codegen::task;
-
 /////////////////
 // Submodules. //
 /////////////////
 
-// Defines the `Celery` app struct which the primary publich interface to Rusty Celery,
-// used to produce or consume tasks.
-pub mod app;
+/// Provides the `Celery` struct that is created by the [`app`](macro.app.html). This is the
+/// primary API for producing and consuming tasks.
+mod app;
 
-// The broker is an integral part of a `Celery` app. It provides the transport for
-// producing and consuming tasks.
+/// The broker is an integral part of a `Celery` app. It provides the transport for messages that
+/// encode tasks.
 pub mod broker;
 
-// Macros for defining apps and tasks.
+/// Macros for defining apps and tasks.
 #[cfg(feature = "codegen")]
 mod codegen;
 
-// Defines the `Error` type used across Rusty Celery.
+/// Error types.
 pub mod error;
 
-// Used only by the codegen modules.
+/// Used only by the codegen modules.
 #[cfg(feature = "codegen")]
 #[doc(hidden)]
 pub mod export;
 
-// Defines the Celery protocol.
+/// Defines the Celery protocol.
 pub mod protocol;
 
-// Provides the `Task` trait. Tasks are then created by defining a struct and implementing
-// this trait for the struct. However the `#[task]` macro provided by `celery-codegen`
-// abstracts most of this away.
-pub mod task;
+/// Provides the `Task` trait as well as options for configuring tasks.
+mod task;
+
+/////////////////
+// Public API. //
+/////////////////
+
+pub use app::{Celery, CeleryBuilder};
+pub use task::{Task, TaskContext, TaskOptions, TaskSendOptions};
+
+#[cfg(feature = "codegen")]
+pub use celery_codegen::task;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
 //! Define tasks by decorating functions with the [`task`](attr.task.html) attribute:
 //!
 //! ```rust
-//! # use celery::task;
-//! #[task]
+//! #[celery::task]
 //! fn add(x: i32, y: i32) -> i32 {
 //!     x + y
 //! }
@@ -17,13 +16,12 @@
 //! macro and register your tasks with it:
 //!
 //! ```rust,no_run
-//! # use celery::{celery_app, task, AMQPBroker};
-//! # #[task]
+//! # #[celery::task]
 //! # fn add(x: i32, y: i32) -> i32 {
 //! #     x + y
 //! # }
-//! let my_app = celery_app!(
-//!     broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+//! let my_app = celery::app!(
+//!     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 //!     tasks = [add],
 //!     task_routes = [],
 //! );
@@ -33,15 +31,14 @@
 //! queue for a worker to consume, use the [`Celery::send_task`](struct.Celery.html#method.send_task) method:
 //!
 //! ```rust,no_run
-//! # use celery::{celery_app, task, AMQPBroker};
-//! # #[task]
+//! # #[celery::task]
 //! # fn add(x: i32, y: i32) -> i32 {
 //! #     x + y
 //! # }
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), exitfailure::ExitFailure> {
-//! # let my_app = celery_app!(
-//! #     broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+//! # let my_app = celery::app!(
+//! #     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 //! #     tasks = [add],
 //! #     task_routes = [],
 //! # );
@@ -54,15 +51,14 @@
 //! [`Celery::consume`](struct.Celery.html#method.consume) method:
 //!
 //! ```rust,no_run
-//! # use celery::{celery_app, task, AMQPBroker};
-//! # #[task]
+//! # #[celery::task]
 //! # fn add(x: i32, y: i32) -> i32 {
 //! #     x + y
 //! # }
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), exitfailure::ExitFailure> {
-//! # let my_app = celery_app!(
-//! #     broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+//! # let my_app = celery::app!(
+//! #     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 //! #     tasks = [add],
 //! #     task_routes = [],
 //! # );
@@ -97,24 +93,27 @@ extern crate async_trait;
 #[cfg(feature = "codegen")]
 extern crate serde;
 
+#[cfg(feature = "codegen")]
+pub use celery_codegen::task;
+
 /////////////////
 // Submodules. //
 /////////////////
 
 // Defines the `Celery` app struct which the primary publich interface to Rusty Celery,
 // used to produce or consume tasks.
-mod app;
+pub mod app;
 
 // The broker is an integral part of a `Celery` app. It provides the transport for
 // producing and consuming tasks.
-mod broker;
+pub mod broker;
 
-// Macro rules for quickly defining apps.
+// Macros for defining apps and tasks.
 #[cfg(feature = "codegen")]
 mod codegen;
 
 // Defines the `Error` type used across Rusty Celery.
-mod error;
+pub mod error;
 
 // Used only by the codegen modules.
 #[cfg(feature = "codegen")]
@@ -127,19 +126,4 @@ pub mod protocol;
 // Provides the `Task` trait. Tasks are then created by defining a struct and implementing
 // this trait for the struct. However the `#[task]` macro provided by `celery-codegen`
 // abstracts most of this away.
-mod task;
-
-/////////////////
-// Public API. //
-/////////////////
-
-pub use app::{Celery, CeleryBuilder, Rule};
-pub use broker::{
-    amqp::{AMQPBroker, AMQPBrokerBuilder},
-    Broker, BrokerBuilder,
-};
-pub use error::{Error, ErrorKind};
-pub use task::{Task, TaskContext, TaskOptions, TaskSendOptions, TaskSendOptionsBuilder};
-
-#[cfg(feature = "codegen")]
-pub use celery_codegen::task;
+pub mod task;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,6 @@
 // Re-exports. //
 /////////////////
 
-extern crate failure;
-pub use failure::ResultExt;
-
 #[cfg(feature = "codegen")]
 extern crate futures;
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -13,7 +13,7 @@ use std::time::SystemTime;
 use tokio::time::Duration;
 use uuid::Uuid;
 
-use crate::error::Error;
+use crate::error::ProtocolError;
 use crate::task::{Task, TaskOptions, TaskSendOptions};
 
 /// Create a message with a custom configuration.
@@ -23,10 +23,10 @@ pub struct MessageBuilder {
 
 impl MessageBuilder {
     /// Get a new `MessageBuilder` from a task.
-    pub fn new<T: Task>(task: T) -> Result<Self, Error> {
+    pub fn new<T: Task>(task: T) -> Result<Self, ProtocolError> {
         // Serialize the task into the message body.
         let body = MessageBody::new(task);
-        let data = serde_json::to_vec(&body).unwrap();
+        let data = serde_json::to_vec(&body)?;
 
         // Create random correlation id.
         let mut buffer = Uuid::encode_buffer();
@@ -105,16 +105,16 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn builder<T: Task>(task: T) -> Result<MessageBuilder, Error> {
+    pub fn builder<T: Task>(task: T) -> Result<MessageBuilder, ProtocolError> {
         MessageBuilder::new::<T>(task)
     }
 
-    pub fn new<T: Task>(task: T) -> Result<Self, Error> {
+    pub fn new<T: Task>(task: T) -> Result<Self, ProtocolError> {
         Ok(Self::builder(task)?.build())
     }
 
     /// Try deserializing the body.
-    pub fn body<T: Task>(&self) -> Result<MessageBody<T>, Error> {
+    pub fn body<T: Task>(&self) -> Result<MessageBody<T>, ProtocolError> {
         let value: Value = serde_json::from_slice(&self.raw_body)?;
         debug!("Deserialized message body: {:?}", value);
         if let Value::Array(ref vec) = value {
@@ -171,7 +171,7 @@ impl Message {
 }
 
 pub trait TryIntoMessage {
-    fn try_into_message(&self) -> Result<Message, Error>;
+    fn try_into_message(&self) -> Result<Message, ProtocolError>;
 }
 
 /// Message meta data pertaining to the broker.
@@ -287,7 +287,7 @@ mod tests {
     use async_trait::async_trait;
 
     use super::*;
-    use crate::error::Error;
+    use crate::error::TaskError;
     use crate::task::Task;
 
     #[derive(Serialize, Deserialize)]
@@ -302,7 +302,7 @@ mod tests {
 
         type Returns = ();
 
-        async fn run(mut self) -> Result<(), Error> {
+        async fn run(mut self) -> Result<(), TaskError> {
             Ok(())
         }
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! The top part of the protocol is the [`Message` struct](struct.Message.html), which builds on
 //! top of the protocol for a broker. This is why a broker's [delivery
-//! type](../trait.Broker.html#associatedtype.Delivery) must implement
+//! type](../broker/trait.Broker.html#associatedtype.Delivery) must implement
 //! [`TryIntoMessage`](trait.TryIntoMessage.html).
 
 use chrono::{self, DateTime, Utc};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::error::TaskError;
 
 mod options;
 
@@ -25,12 +25,12 @@ pub trait Task: Send + Sync + Serialize + for<'de> Deserialize<'de> {
     type Returns: Send + Sync + std::fmt::Debug;
 
     /// This function defines how a task executes.
-    async fn run(mut self) -> Result<Self::Returns, Error>;
+    async fn run(mut self) -> Result<Self::Returns, TaskError>;
 
     /// Callback that will run after a task fails.
     /// It takes a reference to a `TaskContext` struct and the error returned from task.
     #[allow(unused_variables)]
-    async fn on_failure(ctx: &TaskContext<'_>, err: &Error) {}
+    async fn on_failure(ctx: &TaskContext<'_>, err: &TaskError) {}
 
     /// Callback that will run after a task completes successfully.
     /// It takes a reference to a `TaskContext` struct and the returned value from task.

--- a/tests/brokers/amqp.rs
+++ b/tests/brokers/amqp.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use celery::error::TaskError;
-use celery::{Task, TaskContext};
+use celery::task::{Task, TaskContext};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/tests/brokers/amqp.rs
+++ b/tests/brokers/amqp.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use celery::error::TaskError;
-use celery::task::{Task, TaskContext};
+use celery::{Task, TaskContext};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,6 +1,6 @@
-use celery::{task, Task};
+use celery::task::Task;
 
-#[task(name = "add")]
+#[celery::task(name = "add")]
 fn add(x: i32, y: i32) -> i32 {
     x + y
 }
@@ -15,7 +15,7 @@ fn test_add_arg_names() {
     assert_eq!(add::ARGS, &["x", "y"]);
 }
 
-#[task]
+#[celery::task]
 fn add_auto_name(x: i32, y: i32) -> i32 {
     x + y
 }
@@ -25,7 +25,7 @@ fn test_auto_name() {
     assert_eq!(add_auto_name::NAME, "add_auto_name");
 }
 
-#[task(
+#[celery::task(
     timeout = 2,
     max_retries = 3,
     min_retry_delay = 0,
@@ -58,7 +58,7 @@ fn test_task_options() {
 // which doesn't compile since String doesn't implement Copy.
 //
 // After changing the signature of `run` to consume `self` this now works.
-#[task]
+#[celery::task]
 fn task_with_strings(s1: String, s2: String) -> String {
     format!("{}, {}", s1, s2)
 }

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,4 +1,4 @@
-use celery::task::Task;
+use celery::Task;
 
 #[celery::task(name = "add")]
 fn add(x: i32, y: i32) -> i32 {

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,4 +1,4 @@
-use celery::Task;
+use celery::task::Task;
 
 #[celery::task(name = "add")]
 fn add(x: i32, y: i32) -> i32 {


### PR DESCRIPTION
The public API was getting a bit unwieldy due to having everything publicly available from the crate root and only having one error type.

This breaks up the error type and makes the submodules public while keeping the crate root clean. To keep things from getting too verbose I made the `celery_app!` macro simpler and changed its name to just `app!`. Previously you would do something like this:

```rust
use celery::{celery_app, AMQPBroker};

my_app  = celery_app! {
    broker = AMQPBroker { "amqp://..." },
    tasks = [],
}
```

where now you would do this:

```rust
my_app = celery::app! {
    broker = AMQP { "amqp://..." },
    tasks = [],
}
```

Also closes #95 