### PR TITLE
improve retry functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Retry ETA method moved from tracer to task so that it can be customized.
+- `TaskError` variants restricted to only `ExpectedError`, `UnexpectedError`, and `TimeoutError`. The `Retry` and `ExpirationError` variants moved to a new (non-public) error type: `TracerError`.
+
 ## [0.2.1] - 2019-03-05
 
 ### Added

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ mod routing;
 mod trace;
 
 use crate::broker::{Broker, BrokerBuilder};
-use crate::error::{BrokerError, CeleryError, TaskError};
+use crate::error::{BrokerError, CeleryError, TraceError};
 use crate::protocol::{Message, TryCreateMessage};
 use crate::task::{Signature, Task, TaskEvent, TaskOptions, TaskStatus};
 use routing::Rule;
@@ -355,8 +355,7 @@ where
         // we only log errors at the broker and delivery level.
         if let Err(e) = tracer.trace().await {
             // If retry error -> retry the task.
-            if let TaskError::Retry = e {
-                let retry_eta = tracer.retry_eta();
+            if let TraceError::Retry(retry_eta) = e {
                 self.broker
                     .retry(&delivery, retry_eta)
                     .await

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types.
 
+use chrono::{DateTime, Utc};
 use failure::{Context, Fail};
 
 /// Errors that can occur while creating or using a `Celery` app.
@@ -37,7 +38,7 @@ pub enum CeleryError {
     UnregisteredTaskError(String),
 }
 
-/// Errors that can occur while running or tracing a task.
+/// Errors that can occur at the task level.
 #[derive(Debug, Fail)]
 pub enum TaskError {
     /// An error that is expected to happen every once in a while and should trigger
@@ -49,17 +50,25 @@ pub enum TaskError {
     #[fail(display = "{}", _0)]
     UnexpectedError(String),
 
+    /// Raised when a task runs over its time limit.
+    #[fail(display = "Task timed out")]
+    TimeoutError,
+}
+
+/// Errors that can occur while tracing a task.
+#[derive(Debug, Fail)]
+pub(crate) enum TraceError {
+    /// Raised when a task throws an error while executing.
+    #[fail(display = "Task failed with {}", _0)]
+    TaskError(TaskError),
+
     /// Raised when an expired task is received.
     #[fail(display = "Task expired")]
     ExpirationError,
 
     /// Raised when a task should be retried.
     #[fail(display = "Retrying task")]
-    Retry,
-
-    /// Raised when a task runs over its time limit.
-    #[fail(display = "Task timed out")]
-    TimeoutError,
+    Retry(Option<DateTime<Utc>>),
 }
 
 /// Errors that can occur at the broker level.


### PR DESCRIPTION
- Retry ETA method moved from tracer to `Task` trait so that it can be customized
- `TaskError` variants restricted to only `ExpectedError`, `UnexpectedError`, and `TimeoutError`. The `Retry` and `ExpirationError` variants moved to a new (non-public) error type: `TracerError`.