### PR TITLE
updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `CeleryBuilder::task_route` now infallible. Error could be raised during the `build` phase instead.
+- `Celery::consume_from` will return `Err(CeleryError::NoQueueToConsume)` if the slice of queues is empty.
 
 ## [0.2.2] - 2019-03-06
 

--- a/celery-codegen/src/lib.rs
+++ b/celery-codegen/src/lib.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "256"]
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 
 mod error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,10 @@ pub enum CeleryError {
     #[fail(display = "Unknown queue '{}'", _0)]
     UnknownQueue(String),
 
+    /// Raised when `Celery::consume_from` is given an empty array of queues.
+    #[fail(display = "At least one queue required to consume from")]
+    NoQueueToConsume,
+
     /// Forced shutdown.
     #[fail(display = "Forced shutdown")]
     ForcedShutdown,


### PR DESCRIPTION
- Update for Rust 1.42.0 (`extern crate proc_macro` no longer needed)
- Make `Celery::consume_from` return an error if `queues` is empty