### PR TITLE
specify single build target for doc.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/rusty-celery/rusty-celery"
 homepage = "https://github.com/rusty-celery/rusty-celery"
 description = "Rust implementation of Celery"
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [lib]
 name = "celery"
 path = "src/lib.rs"


### PR DESCRIPTION
See https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html