### PR TITLE
Enforce tasks to explicitly return a `TaskResult<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Tasks must explicity return a `TaskResult<T>` now.
+
 ## [0.2.4] - 2019-03-16
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ If you already know the basics of Rust, the [Rusty Celery Book](https://rusty-ce
 Define tasks by decorating functions with the [`task`](https://docs.rs/celery/*/celery/attr.task.html) attribute.
 
 ```rust
+use celery::TaskResult;
+
 #[celery::task]
-fn add(x: i32, y: i32) -> i32 {
-    x + y
+fn add(x: i32, y: i32) -> TaskResult<i32> {
+    Ok(x + y)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <br>
     <img src="https://structurely-images.s3-us-west-2.amazonaws.com/logos/rusty-celery.png" width="600"/>
     <br>
-<p>
+</p>
 <p align="center">
     <a href="https://github.com/rusty-celery/rusty-celery/actions">
         <img alt="Build" src="https://github.com/rusty-celery/rusty-celery/workflows/CI/badge.svg?event=push&branch=master">

--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -523,7 +523,25 @@ impl ToTokens for Task {
             }
         };
 
-        let run_implementation = if self.is_async {
+        let run_implementation = if self.return_type.is_none() {
+            if self.is_async {
+                quote! {
+                    impl #wrapper {
+                        async fn _run(#typed_run_inputs) -> #return_type {
+                            Ok(#inner_block)
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    impl #wrapper {
+                        fn _run(#typed_run_inputs) -> #return_type {
+                            Ok(#inner_block)
+                        }
+                    }
+                }
+            }
+        } else if self.is_async {
             quote! {
                 impl #wrapper {
                     async fn _run(#typed_run_inputs) -> #return_type {

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use celery::error::TaskError;
-use celery::task::Task;
+use celery::task::{Task, TaskResult};
 use env_logger::Env;
 use exitfailure::ExitFailure;
 use structopt::StructOpt;
@@ -10,18 +10,17 @@ use tokio::time::{self, Duration};
 
 // This generates the task struct and impl with the name set to the function name "add"
 #[celery::task]
-fn add(x: i32, y: i32) -> i32 {
-    x + y
+fn add(x: i32, y: i32) -> TaskResult<i32> {
+    Ok(x + y)
 }
 
 // Demonstrates a task that raises an error, and also how to customize task options.
 // In this case we override the default `max_retries`.
 #[celery::task(max_retries = 3)]
 fn buggy_task() {
-    #[allow(clippy::try_err)]
     Err(TaskError::UnexpectedError(
         "This error is part of the example: it is used to showcase a buggy task".into(),
-    ))?
+    ))
 }
 
 // Demonstrates a long running IO-bound task. By increasing the prefetch count, an arbitrary
@@ -30,12 +29,13 @@ fn buggy_task() {
 async fn long_running_task(secs: Option<u64>) {
     let secs = secs.unwrap_or(10);
     time::delay_for(Duration::from_secs(secs)).await;
+    Ok(())
 }
 
 // Demonstrates a task that is bound to the task instance, i.e. runs as an instance method.
 #[celery::task(bind = true)]
-fn bound_task(task: &Self) -> Option<u32> {
-    task.timeout()
+fn bound_task(task: &Self) -> TaskResult<Option<u32>> {
+    Ok(task.timeout())
 }
 
 #[derive(Debug, StructOpt)]

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -17,7 +17,7 @@ fn add(x: i32, y: i32) -> TaskResult<i32> {
 // Demonstrates a task that raises an error, and also how to customize task options.
 // In this case we override the default `max_retries`.
 #[celery::task(max_retries = 3)]
-fn buggy_task() {
+fn buggy_task() -> TaskResult<()> {
     Err(TaskError::UnexpectedError(
         "This error is part of the example: it is used to showcase a buggy task".into(),
     ))
@@ -29,7 +29,6 @@ fn buggy_task() {
 async fn long_running_task(secs: Option<u64>) {
     let secs = secs.unwrap_or(10);
     time::delay_for(Duration::from_secs(secs)).await;
-    Ok(())
 }
 
 // Demonstrates a task that is bound to the task instance, i.e. runs as an instance method.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -69,9 +69,11 @@ macro_rules! __app_internal {
 ///
 /// ```rust,no_run
 /// # #[macro_use] extern crate celery;
+/// use celery::TaskResult;
+///
 /// #[celery::task]
-/// fn add(x: i32, y: i32) -> i32 {
-///     x + y
+/// fn add(x: i32, y: i32) -> TaskResult<i32> {
+///     Ok(x + y)
 /// }
 ///
 /// # fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ mod codegen;
 
 /// A procedural macro for generating a [`Task`](task/trait.Task.html) from a function.
 ///
+/// If the annotated function has a return value, the return value must be a
+/// [`TaskResult<R>`](task/type.TaskResult.html).
+///
 /// # Parameters
 ///
 /// - `name`: The name to use when registering the task. Should be unique. If not given the name
@@ -154,9 +157,8 @@ mod codegen;
 /// ```rust
 /// # use celery::task::{Task, TaskResult};
 /// #[celery::task(bind = true)]
-/// fn bound_task(task: &Self) -> TaskResult<()> {
+/// fn bound_task(task: &Self) {
 ///     println!("Hello, World! From {}", task.name());
-///     Ok(())
 /// }
 /// ```
 ///
@@ -166,7 +168,7 @@ mod codegen;
 /// # use celery::task::{Task, TaskResult};
 /// # use celery::error::TaskError;
 /// #[celery::task(on_failure = failure_callback, on_success = success_callback)]
-/// fn task_with_callbacks() -> TaskResult<()> { Ok(()) }
+/// fn task_with_callbacks() {}
 ///
 /// async fn failure_callback<T: Task>(task: &T, err: &TaskError) {
 ///     println!("{} failed with {:?}", task.name(), err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,6 @@ mod codegen;
 ///
 /// ```rust
 /// # use celery::TaskResult;
-///
 /// #[celery::task(name = "sum")]
 /// fn add(x: i32, y: i32) -> TaskResult<i32> {
 ///     Ok(x + y)
@@ -153,9 +152,9 @@ mod codegen;
 /// Bind the function to the task instance so it runs like an instance method:
 ///
 /// ```rust
-/// # use celery::task::Task;
+/// # use celery::task::{Task, TaskResult};
 /// #[celery::task(bind = true)]
-/// fn bound_task(task: &Self) {
+/// fn bound_task(task: &Self) -> TaskResult<()> {
 ///     println!("Hello, World! From {}", task.name());
 ///     Ok(())
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ mod app;
 pub use app::{Celery, CeleryBuilder};
 pub mod broker;
 pub mod error;
+pub use error::TaskResultExt;
 pub mod protocol;
 pub mod task;
 pub use task::TaskResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@
 //! Define tasks by decorating functions with the [`task`](attr.task.html) attribute:
 //!
 //! ```rust
+//! use celery::TaskResult;
+//!
 //! #[celery::task]
-//! fn add(x: i32, y: i32) -> i32 {
-//!     x + y
+//! fn add(x: i32, y: i32) -> TaskResult<i32> {
+//!     Ok(x + y)
 //! }
 //! ```
 //!
@@ -17,8 +19,8 @@
 //!
 //! ```rust,no_run
 //! # #[celery::task]
-//! # fn add(x: i32, y: i32) -> i32 {
-//! #     x + y
+//! # fn add(x: i32, y: i32) -> celery::TaskResult<i32> {
+//! #     Ok(x + y)
 //! # }
 //! let my_app = celery::app!(
 //!     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
@@ -32,8 +34,8 @@
 //!
 //! ```rust,no_run
 //! # #[celery::task]
-//! # fn add(x: i32, y: i32) -> i32 {
-//! #     x + y
+//! # fn add(x: i32, y: i32) -> celery::TaskResult<i32> {
+//! #     Ok(x + y)
 //! # }
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), exitfailure::ExitFailure> {
@@ -52,8 +54,8 @@
 //!
 //! ```rust,no_run
 //! # #[celery::task]
-//! # fn add(x: i32, y: i32) -> i32 {
-//! #     x + y
+//! # fn add(x: i32, y: i32) -> celery::TaskResult<i32> {
+//! #     Ok(x + y)
 //! # }
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), exitfailure::ExitFailure> {
@@ -80,6 +82,7 @@ pub mod broker;
 pub mod error;
 pub mod protocol;
 pub mod task;
+pub use task::TaskResult;
 
 #[cfg(feature = "codegen")]
 mod codegen;
@@ -112,32 +115,38 @@ mod codegen;
 /// Create a task named `add` with all of the default options:
 ///
 /// ```rust
+/// use celery::TaskResult;
+///
 /// #[celery::task]
-/// fn add(x: i32, y: i32) -> i32 {
-///     x + y
+/// fn add(x: i32, y: i32) -> TaskResult<i32> {
+///     Ok(x + y)
 /// }
 /// ```
 ///
 /// Use a name different from the function name:
 ///
 /// ```rust
+/// # use celery::TaskResult;
+///
 /// #[celery::task(name = "sum")]
-/// fn add(x: i32, y: i32) -> i32 {
-///     x + y
+/// fn add(x: i32, y: i32) -> TaskResult<i32> {
+///     Ok(x + y)
 /// }
 /// ```
 ///
 /// Customize the default retry behavior:
 ///
 /// ```rust
+/// # use celery::TaskResult;
 /// #[celery::task(
 ///     timeout = 3,
 ///     max_retries = 100,
 ///     min_retry_delay = 1,
 ///     max_retry_delay = 60,
 /// )]
-/// async fn io_task() {
+/// async fn io_task() -> TaskResult<()> {
 ///     // Do some async IO work that could possible fail, such as an HTTP request...
+///     Ok(())
 /// }
 /// ```
 ///
@@ -148,16 +157,17 @@ mod codegen;
 /// #[celery::task(bind = true)]
 /// fn bound_task(task: &Self) {
 ///     println!("Hello, World! From {}", task.name());
+///     Ok(())
 /// }
 /// ```
 ///
 /// Run custom callbacks on failure and on success:
 ///
 /// ```rust
-/// # use celery::task::Task;
+/// # use celery::task::{Task, TaskResult};
 /// # use celery::error::TaskError;
 /// #[celery::task(on_failure = failure_callback, on_success = success_callback)]
-/// fn task_with_callbacks() {}
+/// fn task_with_callbacks() -> TaskResult<()> { Ok(()) }
 ///
 /// async fn failure_callback<T: Task>(task: &T, err: &TaskError) {
 ///     println!("{} failed with {:?}", task.name(), err);

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -16,8 +16,20 @@ pub use options::TaskOptions;
 pub use request::Request;
 pub use signature::Signature;
 
-/// A return type for a task.
+/// The return type for a task.
 pub type TaskResult<R> = Result<R, TaskError>;
+
+#[doc(hidden)]
+pub trait AsTaskResult {
+    type Returns: Send + Sync + std::fmt::Debug;
+}
+
+impl<R> AsTaskResult for TaskResult<R>
+where
+    R: Send + Sync + std::fmt::Debug,
+{
+    type Returns = R;
+}
 
 /// A `Task` represents a unit of work that a `Celery` app can produce or consume.
 ///

--- a/src/task/signature.rs
+++ b/src/task/signature.rs
@@ -9,9 +9,11 @@ use chrono::{DateTime, Utc};
 /// # Examples
 ///
 /// ```rust
+/// use celery::TaskResult;
+///
 /// #[celery::task]
-/// fn add(x: i32, y: i32) -> i32 {
-///     x + y
+/// fn add(x: i32, y: i32) -> TaskResult<i32> {
+///     Ok(x + y)
 /// }
 ///
 /// let signature = add::new(1, 2);

--- a/tests/task_codegen/mod.rs
+++ b/tests/task_codegen/mod.rs
@@ -93,5 +93,9 @@ async fn task_on_success<T: Task>(task: &T, _ret: &T::Returns) {
 #[celery::task(on_failure = task_on_failure, on_success = task_on_success)]
 fn task_with_callbacks() {
     println!("Yeup yeup yeup");
-    Ok(())
+}
+
+#[celery::task]
+fn inferred_return_type() {
+    println!("Yeeeup");
 }

--- a/tests/task_codegen/mod.rs
+++ b/tests/task_codegen/mod.rs
@@ -1,9 +1,9 @@
 use celery::error::TaskError;
-use celery::task::Task;
+use celery::task::{Task, TaskResult};
 
 #[celery::task(name = "add")]
-fn add(x: i32, y: i32) -> i32 {
-    x + y
+fn add(x: i32, y: i32) -> TaskResult<i32> {
+    Ok(x + y)
 }
 
 #[test]
@@ -17,8 +17,8 @@ fn test_add_arg_names() {
 }
 
 #[celery::task]
-fn add_auto_name(x: i32, y: i32) -> i32 {
-    x + y
+fn add_auto_name(x: i32, y: i32) -> TaskResult<i32> {
+    Ok(x + y)
 }
 
 #[test]
@@ -34,8 +34,8 @@ fn test_auto_name() {
     retry_for_unexpected = false,
     acks_late = true
 )]
-fn task_with_options() -> String {
-    "it worked!".into()
+fn task_with_options() -> TaskResult<String> {
+    Ok("it worked!".into())
 }
 
 #[test]
@@ -52,13 +52,13 @@ fn test_task_options() {
 }
 
 #[celery::task(bind = true)]
-fn bound_task(t: &Self) -> Option<u32> {
-    t.timeout()
+fn bound_task(t: &Self) -> TaskResult<Option<u32>> {
+    Ok(t.timeout())
 }
 
 #[celery::task(bind = true)]
-fn bound_task_with_other_params(t: &Self, default_timeout: u32) -> u32 {
-    t.timeout().unwrap_or(default_timeout)
+fn bound_task_with_other_params(t: &Self, default_timeout: u32) -> TaskResult<u32> {
+    Ok(t.timeout().unwrap_or(default_timeout))
 }
 
 // This didn't work before since Task::run took a reference to self
@@ -74,8 +74,8 @@ fn bound_task_with_other_params(t: &Self, default_timeout: u32) -> u32 {
 //
 // After changing the signature of `run` to consume `self` this now works.
 #[celery::task]
-fn task_with_strings(s1: String, s2: String) -> String {
-    format!("{}, {}", s1, s2)
+fn task_with_strings(s1: String, s2: String) -> TaskResult<String> {
+    Ok(format!("{}, {}", s1, s2))
 }
 
 async fn task_on_failure<T: Task>(task: &T, _err: &TaskError) {
@@ -93,4 +93,5 @@ async fn task_on_success<T: Task>(task: &T, _ret: &T::Returns) {
 #[celery::task(on_failure = task_on_failure, on_success = task_on_success)]
 fn task_with_callbacks() {
     println!("Yeup yeup yeup");
+    Ok(())
 }


### PR DESCRIPTION
Currently tasks are defined like this:

```rust
#[celery::task]
fn add(x: i32, y: i32) -> i32 {
    x + y
}
```

where the `-> i32` would actually be turned into a `TaskResult<i32>` behind the scenes. This has lead to some confusion about how to handle fallible tasks, a common mistake being annotating the return type as a `TaskResult`:

```rust
#[celery::task]
fn fallible_task() -> TaskResult<()> {
    // ... something that might fail ...
    Ok(())
}
```

But then the return type of `TaskResult<()>` would actually be turned into `TaskResult<TaskResult<()>>`, which is not the intent.

This PR proposes enforcing that all tasks be explicitly defined with a `TaskResult<T>` (with one exception, see below 👇). This means the return type of the task is exactly how it's defined. No trickery will happen behind the scenes, which will clear up the confusion on how to define fallible tasks. The downside is a little more verbosity. For example, the `add` task above now needs to be defined like this:

```rust
#[celery::task]
fn add(x: i32, y: i32) -> TaskResult<i32> {
    Ok(x + y)
}
```

To cut down on some verbosity though, if the task is infallible and the annotated function has no return value (i.e. the return value is `()`), we can infer the task return type of `TaskResult<()>`. Therefore this is perfectly valid:

```rust
#[celery::task]
fn hello() {
    println!("Hello!");
}
```

and  equivalent to

```rust
#[celery::task]
fn hello() -> TaskResult<()> {
    println!("Hello!");
    Ok(())
}
```