### PR TITLE
Adjust signal handling for windows specific compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,51 @@ jobs:
         command: test
         args: --no-run --test codegen app_codegen
 
+  windows_compilation_test:
+    name: Test Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Rust Stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          override: true
+
+      - name: Run unit tests
+        if: always()
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --lib
+
+      - name: Run doc tests
+        if: always()
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --doc
+
+      - name: Run task codegen tests
+        if: always()
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --test codegen task_codegen
+
+      - name: Compile app codegen tests
+        if: always()
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --test codegen app_codegen
+
+
   broker_amqp_test:
     name: Check Broker (AMQP)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     services:
       rabbitmq:
         image: rabbitmq
@@ -140,7 +179,6 @@ jobs:
         override: true
 
     - name: Fix ~/.cargo directory permissions
-      if: matrix.os == 'ubuntu-latest'
       run: |
         # Need to chown ~/.cargo or else the "Cache cargo registry" step will fail.
         # See https://github.com/actions/cache/issues/133.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
 
     - name: Publish celery
       run: |
-        # Wait a few seconds to publish the main crate since it depends on the
+        # Wait a minute to publish the main crate since it depends on the
         # new versions of the other workspace crates.
-        sleep 10
+        sleep 60
         cargo publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,10 @@ jobs:
 
   broker_amqp_test:
     name: Check Broker (AMQP)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     services:
       rabbitmq:
         image: rabbitmq
@@ -137,6 +140,7 @@ jobs:
         override: true
 
     - name: Fix ~/.cargo directory permissions
+      if: matrix.os == 'ubuntu-latest'
       run: |
         # Need to chown ~/.cargo or else the "Cache cargo registry" step will fail.
         # See https://github.com/actions/cache/issues/133.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `beat` module with basic support for scheduling tasks.
 - `beat` macro to create a `Beat` app.
 
+### Fixed
+
+- Compiles on Windows
+
 ## v0.3.0 - 2020-05-28
 
 ### Changed


### PR DESCRIPTION
Fixes https://github.com/rusty-celery/rusty-celery/issues/150

This basically allows compilation on windows, but isn't *exactly* semantically equivalent as signals are handled differently in windows.  The behaviour of unix systems remains the same.