### PR TITLE
rename timeout -> time_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `timeout` task option was renamed to `time_limit` to be more consistent with the Python API.
+
 ## v0.3.1 - 2020-07-22
 
 ### Added

--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -38,7 +38,7 @@ struct Task {
     name: Option<String>,
     wrapper: Option<syn::Ident>,
     params_type: Option<syn::Ident>,
-    timeout: Option<syn::LitInt>,
+    time_limit: Option<syn::LitInt>,
     max_retries: Option<syn::LitInt>,
     min_retry_delay: Option<syn::LitInt>,
     max_retry_delay: Option<syn::LitInt>,
@@ -85,7 +85,7 @@ impl TaskAttrs {
             .next()
     }
 
-    fn timeout(&self) -> Option<syn::LitInt> {
+    fn time_limit(&self) -> Option<syn::LitInt> {
         self.attrs
             .iter()
             .filter_map(|a| match a {
@@ -189,7 +189,7 @@ mod kw {
     syn::custom_keyword!(name);
     syn::custom_keyword!(wrapper);
     syn::custom_keyword!(params_type);
-    syn::custom_keyword!(timeout);
+    syn::custom_keyword!(time_limit);
     syn::custom_keyword!(max_retries);
     syn::custom_keyword!(min_retry_delay);
     syn::custom_keyword!(max_retry_delay);
@@ -215,8 +215,8 @@ impl parse::Parse for TaskAttr {
             input.parse::<kw::params_type>()?;
             input.parse::<Token![=]>()?;
             Ok(TaskAttr::ParamsType(input.parse()?))
-        } else if lookahead.peek(kw::timeout) {
-            input.parse::<kw::timeout>()?;
+        } else if lookahead.peek(kw::time_limit) {
+            input.parse::<kw::time_limit>()?;
             input.parse::<Token![=]>()?;
             Ok(TaskAttr::Timeout(input.parse()?))
         } else if lookahead.peek(kw::max_retries) {
@@ -265,7 +265,7 @@ impl Task {
             name: attrs.name(),
             wrapper: attrs.wrapper(),
             params_type: attrs.params_type(),
-            timeout: attrs.timeout(),
+            time_limit: attrs.time_limit(),
             max_retries: attrs.max_retries(),
             min_retry_delay: attrs.min_retry_delay(),
             max_retry_delay: attrs.max_retry_delay(),
@@ -457,8 +457,8 @@ impl ToTokens for Task {
         let vis = &self.visibility;
         let wrapper = self.wrapper.as_ref().unwrap();
         let params_type = self.params_type.as_ref().unwrap();
-        let timeout = self
-            .timeout
+        let time_limit = self
+            .time_limit
             .as_ref()
             .map(|r| quote! { Some(#r) })
             .unwrap_or_else(|| quote! { None });
@@ -608,7 +608,7 @@ impl ToTokens for Task {
                     const NAME: &'static str = #task_name;
                     const ARGS: &'static [&'static str] = &[#arg_names];
                     const DEFAULTS: #krate::task::TaskOptions = #krate::task::TaskOptions {
-                        timeout: #timeout,
+                        time_limit: #time_limit,
                         max_retries: #max_retries,
                         min_retry_delay: #min_retry_delay,
                         max_retry_delay: #max_retry_delay,

--- a/examples/celery_app.rs
+++ b/examples/celery_app.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), ExitFailure> {
 
             // Send the long running task that will fail with a timeout error.
             my_app
-                .send_task(long_running_task::new(Some(3)).with_timeout(2))
+                .send_task(long_running_task::new(Some(3)).with_time_limit(2))
                 .await?;
         }
     };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -64,7 +64,7 @@ where
                 broker_connection_max_retries: 4,
                 default_queue: "celery".into(),
                 task_options: TaskOptions {
-                    timeout: None,
+                    time_limit: None,
                     max_retries: None,
                     min_retry_delay: None,
                     max_retry_delay: None,
@@ -109,10 +109,10 @@ where
         self
     }
 
-    /// Set an app-level timeout for tasks (see
-    /// [`TaskOption::timeout`](task/struct.TaskOptions.html#structfield.timeout)).
-    pub fn task_timeout(mut self, task_timeout: u32) -> Self {
-        self.config.task_options.timeout = Some(task_timeout);
+    /// Set an app-level time limit for tasks (see
+    /// [`TaskOption::time_limit`](task/struct.TaskOptions.html#structfield.time_limit)).
+    pub fn task_time_limit(mut self, task_time_limit: u32) -> Self {
+        self.config.task_options.time_limit = Some(task_time_limit);
         self
     }
 

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -66,9 +66,9 @@ where
             });
 
         let start = Instant::now();
-        let result = match self.task.timeout() {
+        let result = match self.task.time_limit() {
             Some(secs) => {
-                debug!("Executing task with {} second timeout", secs);
+                debug!("Executing task with {} second time limit", secs);
                 let duration = Duration::from_secs(secs as u64);
                 time::timeout(duration, self.task.run(self.task.request().params.clone()))
                     .await

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -79,7 +79,7 @@ macro_rules! __beat_internal {
 /// [`CeleryBuilder::default_queue`](struct.CeleryBuilder.html#method.default_queue).
 /// - `prefetch_count`: Set the [`CeleryBuilder::prefect_count`](struct.CeleryBuilder.html#method.prefect_count).
 /// - `heartbeat`: Set the [`CeleryBuilder::heartbeat`](struct.CeleryBuilder.html#method.heartbeat).
-/// - `task_timeout`: Set an app-level [`TaskOptions::timeout`](task/struct.TaskOptions.html#structfield.timeout).
+/// - `task_time_limit`: Set an app-level [`TaskOptions::time_limit`](task/struct.TaskOptions.html#structfield.time_limit).
 /// - `task_max_retries`: Set an app-level [`TaskOptions::max_retries`](task/struct.TaskOptions.html#structfield.max_retries).
 /// - `task_min_retry_delay`: Set an app-level [`TaskOptions::min_retry_delay`](task/struct.TaskOptions.html#structfield.min_retry_delay).
 /// - `task_max_retry_delay`: Set an app-level [`TaskOptions::max_retry_delay`](task/struct.TaskOptions.html#structfield.max_retry_delay).
@@ -119,7 +119,7 @@ macro_rules! __beat_internal {
 ///     broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
 ///     tasks = [],
 ///     task_routes = [],
-///     task_timeout = 2
+///     task_time_limit = 2
 /// );
 /// # }
 /// ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,13 +83,13 @@ pub enum TaskError {
     UnexpectedError(String),
 
     /// Raised when a task runs over its time limit specified by the
-    /// [`TaskOptions::timeout`](../task/struct.TaskOptions.html#structfield.timeout) setting.
+    /// [`TaskOptions::time_limit`](../task/struct.TaskOptions.html#structfield.time_limit) setting.
     ///
     /// These errors are logged at the `ERROR` level but are otherwise treated like
     /// `ExpectedError`s in that they will trigger a retry when `max_retries` is anything but 0.
     ///
     /// Typically a task implementation doesn't need to return these errors directly
-    /// because they will be raised automatically when the task runs over it's `timeout`,
+    /// because they will be raised automatically when the task runs over it's `time_limit`,
     /// provided the task yields control at some point (like with non-blocking IO).
     #[fail(display = "TaskError: task timed out")]
     TimeoutError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod codegen;
 ///
 /// - `name`: The name to use when registering the task. Should be unique. If not given the name
 /// will be set to the name of the function being decorated.
-/// - `timeout`: Set a task-level [`TaskOptions::timeout`](task/struct.TaskOptions.html#structfield.timeout).
+/// - `time_limit`: Set a task-level [`TaskOptions::time_limit`](task/struct.TaskOptions.html#structfield.time_limit).
 /// - `max_retries`: Set a task-level [`TaskOptions::max_retries`](task/struct.TaskOptions.html#structfield.max_retries).
 /// - `min_retry_delay`: Set a task-level [`TaskOptions::min_retry_delay`](task/struct.TaskOptions.html#structfield.min_retry_delay).
 /// - `max_retry_delay`: Set a task-level [`TaskOptions::max_retry_delay`](task/struct.TaskOptions.html#structfield.max_retry_delay).
@@ -147,7 +147,7 @@ mod codegen;
 /// ```rust
 /// # use celery::TaskResult;
 /// #[celery::task(
-///     timeout = 3,
+///     time_limit = 3,
 ///     max_retries = 100,
 ///     min_retry_delay = 1,
 ///     max_retry_delay = 60,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -60,8 +60,8 @@ where
         }
     }
 
-    pub fn timeout(mut self, timeout: u32) -> Self {
-        self.message.headers.timelimit = (None, Some(timeout));
+    pub fn time_limit(mut self, time_limit: u32) -> Self {
+        self.message.headers.timelimit = (None, Some(time_limit));
         self
     }
 
@@ -173,8 +173,8 @@ where
 
         let mut builder = MessageBuilder::<T>::new(id);
 
-        if let Some(timeout) = task_sig.timeout.take() {
-            builder = builder.timeout(timeout);
+        if let Some(time_limit) = task_sig.time_limit.take() {
+            builder = builder.time_limit(time_limit);
         }
 
         if let Some(countdown) = task_sig.countdown.take() {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -48,7 +48,7 @@ pub trait Task: Send + Sync + std::marker::Sized {
 
     /// Default task options.
     const DEFAULTS: TaskOptions = TaskOptions {
-        timeout: None,
+        time_limit: None,
         max_retries: None,
         min_retry_delay: None,
         max_retry_delay: None,
@@ -122,10 +122,10 @@ pub trait Task: Send + Sync + std::marker::Sized {
             .unwrap_or(true)
     }
 
-    fn timeout(&self) -> Option<u32> {
+    fn time_limit(&self) -> Option<u32> {
         self.request()
-            .timeout
-            .or_else(|| Self::DEFAULTS.timeout.or(self.options().timeout))
+            .time_limit
+            .or_else(|| Self::DEFAULTS.time_limit.or(self.options().time_limit))
     }
 
     fn max_retries(&self) -> Option<u32> {

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -8,11 +8,11 @@
 /// That is, options set at the request level have the highest precendence,
 /// followed by options set at the task level, and lastly the app level.
 ///
-/// For example, if `timeout: Some(10)` is set at the app level through the
-/// [`task_timeout` option](../struct.CeleryBuilder.html#method.task_timeout),
-/// then every task will use a timeout of 10 seconds unless some other timeout is specified in the
+/// For example, if `time_limit: Some(10)` is set at the app level through the
+/// [`task_time_limit` option](../struct.CeleryBuilder.html#method.task_time_limit),
+/// then every task will use a time limit of 10 seconds unless some other time limit is specified in the
 /// [task definition](attr.task.html#parameters) or in a
-/// [task signature](../task/struct.Signature.html#structfield.timeout) for that task.
+/// [task signature](../task/struct.Signature.html#structfield.time_limit) for that task.
 #[derive(Copy, Clone, Default)]
 pub struct TaskOptions {
     /// Timeout for a task.
@@ -22,15 +22,15 @@ pub struct TaskOptions {
     /// if it runs longer than `n` seconds.
     ///
     /// This can be set with
-    /// - [`task_timeout`](../struct.CeleryBuilder.html#method.task_timeout) at the app level,
-    /// - [`timeout`](../attr.task.html#parameters) at the task level, and
-    /// - [`with_timeout`](../task/struct.Signature.html#method.with_timeout) at the request / signature level.
+    /// - [`task_time_limit`](../struct.CeleryBuilder.html#method.task_time_limit) at the app level,
+    /// - [`time_limit`](../attr.task.html#parameters) at the task level, and
+    /// - [`with_time_limit`](../task/struct.Signature.html#method.with_time_limit) at the request / signature level.
     ///
-    /// If this option is left unspecified, the default behavior will be to enforce no timeout.
+    /// If this option is left unspecified, the default behavior will be to enforce no time limit.
     ///
     /// *Note, however, that only non-blocking tasks can be interrupted, so it's important
     /// to use async functions within task implementations whenever they are available.*
-    pub timeout: Option<u32>,
+    pub time_limit: Option<u32>,
 
     /// Maximum number of retries for this task.
     ///

--- a/src/task/request.rs
+++ b/src/task/request.rs
@@ -46,7 +46,7 @@ where
     pub reply_to: Option<String>,
 
     /// The time limit (in seconds) allocated for this task to execute.
-    pub timeout: Option<u32>,
+    pub time_limit: Option<u32>,
 }
 
 impl<T> Request<T>
@@ -54,7 +54,7 @@ where
     T: Task,
 {
     pub fn new(m: Message, p: T::Params) -> Self {
-        let timeout = match m.headers.timelimit {
+        let time_limit = match m.headers.timelimit {
             (Some(soft_timelimit), Some(hard_timelimit)) => {
                 Some(std::cmp::min(soft_timelimit, hard_timelimit))
             }
@@ -74,7 +74,7 @@ where
             expires: m.headers.expires,
             hostname: None,
             reply_to: m.properties.reply_to,
-            timeout,
+            time_limit,
         }
     }
 

--- a/src/task/signature.rs
+++ b/src/task/signature.rs
@@ -31,8 +31,8 @@ where
     /// A queue to send the task to.
     pub queue: Option<String>,
 
-    /// Timeout for the task execution. Overrides any app or task-level default timeouts.
-    pub timeout: Option<u32>,
+    /// Timeout for the task execution. Overrides any app or task-level default time limits.
+    pub time_limit: Option<u32>,
 
     /// The number of seconds to wait before executing the task. This is equivalent to setting
     /// [`eta`](struct.Signature.html#structfield.eta)
@@ -61,7 +61,7 @@ where
         Self {
             params,
             queue: None,
-            timeout: None,
+            time_limit: None,
             countdown: None,
             eta: None,
             expires_in: None,
@@ -80,9 +80,9 @@ where
         self
     }
 
-    /// Set the timeout.
-    pub fn with_timeout(mut self, timeout: u32) -> Self {
-        self.timeout = Some(timeout);
+    /// Set a time limit (in seconds) for the task.
+    pub fn with_time_limit(mut self, time_limit: u32) -> Self {
+        self.time_limit = Some(time_limit);
         self
     }
 

--- a/tests/app_codegen/mod.rs
+++ b/tests/app_codegen/mod.rs
@@ -42,7 +42,7 @@ fn test_with_options() {
         AMQP { std::env::var("AMQP_ADDR").unwrap() },
         [],
         [],
-        task_timeout = 2
+        task_time_limit = 2
     );
 }
 
@@ -52,7 +52,7 @@ fn test_with_keywords_and_options() {
         broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
         tasks = [],
         task_routes = [],
-        task_timeout = 2
+        task_time_limit = 2
     );
 }
 
@@ -62,7 +62,7 @@ fn test_with_options_and_trailing_comma() {
         AMQP { std::env::var("AMQP_ADDR").unwrap() },
         [],
         [],
-        task_timeout = 2,
+        task_time_limit = 2,
     );
 }
 
@@ -72,6 +72,6 @@ fn test_with_keywords_and_options_and_trailing_comma() {
         broker = AMQP { std::env::var("AMQP_ADDR").unwrap() },
         tasks = [],
         task_routes = [],
-        task_timeout = 2,
+        task_time_limit = 2,
     );
 }

--- a/tests/task_codegen/mod.rs
+++ b/tests/task_codegen/mod.rs
@@ -27,7 +27,7 @@ fn test_auto_name() {
 }
 
 #[celery::task(
-    timeout = 2,
+    time_limit = 2,
     max_retries = 3,
     min_retry_delay = 0,
     max_retry_delay = 60,
@@ -40,7 +40,7 @@ fn task_with_options() -> TaskResult<String> {
 
 #[test]
 fn test_task_options() {
-    assert_eq!(task_with_options::DEFAULTS.timeout, Some(2));
+    assert_eq!(task_with_options::DEFAULTS.time_limit, Some(2));
     assert_eq!(task_with_options::DEFAULTS.max_retries, Some(3));
     assert_eq!(task_with_options::DEFAULTS.min_retry_delay, Some(0));
     assert_eq!(task_with_options::DEFAULTS.max_retry_delay, Some(60));
@@ -53,12 +53,12 @@ fn test_task_options() {
 
 #[celery::task(bind = true)]
 fn bound_task(t: &Self) -> TaskResult<Option<u32>> {
-    Ok(t.timeout())
+    Ok(t.time_limit())
 }
 
 #[celery::task(bind = true)]
-fn bound_task_with_other_params(t: &Self, default_timeout: u32) -> TaskResult<u32> {
-    Ok(t.timeout().unwrap_or(default_timeout))
+fn bound_task_with_other_params(t: &Self, default_time_limit: u32) -> TaskResult<u32> {
+    Ok(t.time_limit().unwrap_or(default_time_limit))
 }
 
 // This didn't work before since Task::run took a reference to self


### PR DESCRIPTION
This renames the task option "timeout" to "time_limit" to be more consistent with the Python API.