### PR TITLE
reorganize beat module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Celery::send_task` now returns an `AsyncResult` instead of a `String` for the `Ok` variant.
+- Renamed `DummyBackend` to `LocalSchedulerBackend`.
 
 ## v0.4.0-rc2 - 2020-08-27
 

--- a/examples/beat_app.rs
+++ b/examples/beat_app.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)]
 
+use celery::beat::RegularSchedule;
 use celery::task::TaskResult;
-use celery::RegularSchedule;
 use env_logger::Env;
 use exitfailure::ExitFailure;
 use tokio::time::Duration;

--- a/src/beat/backend.rs
+++ b/src/beat/backend.rs
@@ -3,7 +3,12 @@ use super::scheduled_task::ScheduledTask;
 use crate::error::BeatError;
 use std::collections::BinaryHeap;
 
-/// This trait is implemented by all `Scheduler` backends.
+/// A `SchedulerBackend` is in charge of keeping track of the internal state of the scheduler
+/// according to some source of truth, such as a database.
+///
+/// The default scheduler backend, [`LocalSchedulerBackend`](struct.LocalSchedulerBackend.html),
+/// doesn't do any external syncronization, so the source of truth is just the locally defined
+/// schedules.
 pub trait SchedulerBackend {
     /// Check whether the internal state of the scheduler should be synchronized.
     /// If this method returns `true`, then `sync` will be called as soon as possible.
@@ -24,17 +29,17 @@ pub trait SchedulerBackend {
     // and the backend has access to that.
 }
 
-/// The only scheduler backend implementation for now. It does basically nothing.
-pub struct DummyBackend {}
+/// The default [`SchedulerBackend`](trait.SchedulerBackend.html).
+pub struct LocalSchedulerBackend {}
 
 #[allow(clippy::new_without_default)]
-impl DummyBackend {
+impl LocalSchedulerBackend {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl SchedulerBackend for DummyBackend {
+impl SchedulerBackend for LocalSchedulerBackend {
     fn should_sync(&self) -> bool {
         false
     }

--- a/src/beat/mod.rs
+++ b/src/beat/mod.rs
@@ -1,26 +1,27 @@
-/// This module contains the implementation of the Celery **beat**, which is a component
-/// that can be used to automatically execute tasks at scheduled times.
-///
-/// ### Terminology
-///
-/// This is the terminology used in this module (with references to the corresponding names
-/// in the Python implementation):
-/// - schedule: the strategy used to decide when a task must be executed (each scheduled
-///   task has its own schedule);
-/// - scheduled task: a task together with its schedule (it more or less corresponds to
-///   a *schedule entry* in Python);
-/// - scheduler: the component in charge of keeping track of tasks to execute;
-/// - backend: the component that updates the internal state of the scheduler according to
-///   to an external source of truth (e.g., a database); there is no equivalent in Python,
-///   due to the fact that another pattern is used (see below);
-/// - beat: the service that drives the execution, calling the appropriate
-///   methods of the scheduler in an infinite loop (called just *service* in Python).
-///
-/// The main difference with the architecture used in Python is that in Python
-/// there is a base scheduler class which contains the scheduling logic, then different
-/// implementations use different strategies to synchronize the scheduler.
-/// Here instead we have only one scheduler struct, and the different backends
-/// correspond to the different scheduler implementations in Python.
+//! This module contains the implementation of the Celery beat, which is a component
+//! that can be used to automatically produce tasks at scheduled times.
+//!
+//! ### Terminology
+//!
+//! This is the terminology used in this module (with references to the corresponding names
+//! in the Python implementation):
+//! - schedule: the strategy used to decide when a task must be executed (each scheduled
+//!   task has its own schedule);
+//! - scheduled task: a task together with its schedule (it more or less corresponds to
+//!   a *schedule entry* in Python);
+//! - scheduler: the component in charge of keeping track of tasks to execute;
+//! - scheduler backend: the component that updates the internal state of the scheduler according to
+//!   to an external source of truth (e.g., a database); there is no equivalent in Python,
+//!   due to the fact that another pattern is used (see below);
+//! - beat: the service that drives the execution, calling the appropriate
+//!   methods of the scheduler in an infinite loop (called just *service* in Python).
+//!
+//! The main difference with the architecture used in Python is that in Python
+//! there is a base scheduler class which contains the scheduling logic, then different
+//! implementations use different strategies to synchronize the scheduler.
+//! Here instead we have only one scheduler struct, and the different backends
+//! correspond to the different scheduler implementations in Python.
+
 use crate::broker::{build_and_connect, configure_task_routes, Broker, BrokerBuilder};
 use crate::routing::{self, Rule};
 use crate::{
@@ -32,10 +33,10 @@ use std::time::SystemTime;
 use tokio::time::{self, Duration};
 
 mod scheduler;
-use scheduler::Scheduler;
+pub use scheduler::Scheduler;
 
 mod backend;
-pub use backend::{DummyBackend, SchedulerBackend};
+pub use backend::{LocalSchedulerBackend, SchedulerBackend};
 
 mod schedule;
 pub use schedule::{RegularSchedule, Schedule};
@@ -67,7 +68,7 @@ where
     scheduler_backend: Sb,
 }
 
-impl<Bb> BeatBuilder<Bb, DummyBackend>
+impl<Bb> BeatBuilder<Bb, LocalSchedulerBackend>
 where
     Bb: BrokerBuilder,
 {
@@ -85,7 +86,7 @@ where
                 default_queue: "celery".into(),
                 task_routes: vec![],
             },
-            scheduler_backend: DummyBackend::new(),
+            scheduler_backend: LocalSchedulerBackend::new(),
         }
     }
 }
@@ -199,12 +200,10 @@ where
     }
 }
 
-/// A `Beat` app is used to execute scheduled tasks. This is the struct that is
-/// created with the [`beat`](macro.beat.html) macro.
+/// A `Beat` app is used to send out scheduled tasks. This is the struct that is
+/// created with the [`beat`](../macro.beat.html) macro.
 ///
-/// The *beat* is in charge of executing scheduled tasks when
-/// they are due and to add or remove tasks as required. It drives execution by
-/// making the internal scheduler "tick", and updates the list of scheduled
+/// It drives execution by making the internal scheduler "tick", and updates the list of scheduled
 /// tasks through a customizable scheduler backend.
 pub struct Beat<Br: Broker, Sb: SchedulerBackend> {
     pub name: String,
@@ -219,14 +218,19 @@ pub struct Beat<Br: Broker, Sb: SchedulerBackend> {
     broker_connection_retry_delay: u32,
 }
 
-impl<Br> Beat<Br, DummyBackend>
+impl<Br> Beat<Br, LocalSchedulerBackend>
 where
     Br: Broker,
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom configuration and a
     /// default scheduler backend.
-    pub fn default_builder(name: &str, broker_url: &str) -> BeatBuilder<Br::Builder, DummyBackend> {
-        BeatBuilder::<Br::Builder, DummyBackend>::with_default_scheduler_backend(name, broker_url)
+    pub fn default_builder(
+        name: &str,
+        broker_url: &str,
+    ) -> BeatBuilder<Br::Builder, LocalSchedulerBackend> {
+        BeatBuilder::<Br::Builder, LocalSchedulerBackend>::with_default_scheduler_backend(
+            name, broker_url,
+        )
     }
 }
 

--- a/src/beat/tests.rs
+++ b/src/beat/tests.rs
@@ -34,10 +34,10 @@ async fn test_task_with_regular_schedule() {
     // Configure a dummy queue for the tasks.
     let task_routes = vec![Rule::new("dummy_*", "dummy_queue").unwrap()];
 
-    let mut beat: Beat<DummyBroker, DummyBackend> = Beat {
+    let mut beat: Beat<DummyBroker, LocalSchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
-        scheduler_backend: DummyBackend::new(),
+        scheduler_backend: LocalSchedulerBackend::new(),
         task_routes,
         default_queue: "celery".to_string(),
         broker_connection_timeout: 5,
@@ -88,10 +88,10 @@ async fn test_scheduling_two_tasks() {
         Rule::new("dummy_task2", "dummy_queue2").unwrap(),
         Rule::new("dummy_*", "dummy_queue").unwrap(),
     ];
-    let mut beat: Beat<DummyBroker, DummyBackend> = Beat {
+    let mut beat: Beat<DummyBroker, LocalSchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
-        scheduler_backend: DummyBackend::new(),
+        scheduler_backend: LocalSchedulerBackend::new(),
         task_routes,
         default_queue: "celery".to_string(),
         broker_connection_timeout: 5,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -46,7 +46,7 @@ macro_rules! __beat_internal {
     ) => {{
         let broker_url = $broker_url;
 
-        let mut builder = $crate::Beat::<$broker_type, _>::custom_builder("beat", &broker_url, $scheduler_backend);
+        let mut builder = $crate::beat::Beat::<$broker_type, _>::custom_builder("beat", &broker_url, $scheduler_backend);
 
         $(
             builder = builder.$x($y);
@@ -155,7 +155,7 @@ macro_rules! app {
 }
 
 // TODO add support for scheduling tasks here.
-/// A macro for creating a [`Beat`](struct.Beat.html) app.
+/// A macro for creating a [`Beat`](beat/struct.Beat.html) app.
 ///
 /// At a minimum the `beat!` macro requires these 2 arguments (in order):
 /// - `broker`: a broker type (currently only AMQP is supported) with an expression for the broker URL in brackets,
@@ -166,22 +166,22 @@ macro_rules! app {
 /// # Custom scheduler backend
 ///
 /// A custom scheduler backend can be given as third argument (with or without using the keyword `scheduler_backend`).
-/// If not given, the default [`DummyBackend`](struct.DummyBackend.html) will be used.
+/// If not given, the default [`LocalSchedulerBackend`](struct.LocalSchedulerBackend.html) will be used.
 ///
 /// # Optional parameters
 ///
 /// A number of other optional parameters can be passed as last arguments and in arbitrary order
-/// (all of which correspond to a method on the [`BeatBuilder`](struct.BeatBuilder.html) struct):
+/// (all of which correspond to a method on the [`BeatBuilder`](beat/struct.BeatBuilder.html) struct):
 ///
 /// - `default_queue`: Set the
-/// [`BeatBuilder::default_queue`](struct.BeatBuilder.html#method.default_queue).
-/// - `heartbeat`: Set the [`BeatBuilder::heartbeat`](struct.BeatBuilder.html#method.heartbeat).
+/// [`BeatBuilder::default_queue`](beat/struct.BeatBuilder.html#method.default_queue).
+/// - `heartbeat`: Set the [`BeatBuilder::heartbeat`](beat/struct.BeatBuilder.html#method.heartbeat).
 /// - `broker_connection_timeout`: Set the
-/// [`BeatBuilder::broker_connection_timeout`](struct.BeatBuilder.html#method.broker_connection_timeout).
+/// [`BeatBuilder::broker_connection_timeout`](beat/struct.BeatBuilder.html#method.broker_connection_timeout).
 /// - `broker_connection_retry`: Set the
-/// [`BeatBuilder::broker_connection_retry`](struct.BeatBuilder.html#method.broker_connection_retry).
+/// [`BeatBuilder::broker_connection_retry`](beat/struct.BeatBuilder.html#method.broker_connection_retry).
 /// - `broker_connection_max_retries`: Set the
-/// [`BeatBuilder::broker_connection_max_retries`](struct.BeatBuilder.html#method.broker_connection_max_retries).
+/// [`BeatBuilder::broker_connection_max_retries`](beat/struct.BeatBuilder.html#method.broker_connection_max_retries).
 ///
 /// # Examples
 ///
@@ -214,7 +214,7 @@ macro_rules! app {
 ///
 /// ```rust,no_run
 /// # #[macro_use] extern crate celery;
-/// use celery::{ScheduledTask, SchedulerBackend, error::BeatError};
+/// use celery::{beat::ScheduledTask, beat::SchedulerBackend, error::BeatError};
 /// use std::collections::BinaryHeap;
 ///
 /// struct CustomSchedulerBackend {}
@@ -249,7 +249,7 @@ macro_rules! beat {
         $crate::__beat_internal!(
             $crate::broker::AMQPBroker { $broker_url },
             [ $( $pattern => $queue ),* ],
-            $crate::DummyBackend::new(),
+            $crate::beat::LocalSchedulerBackend::new(),
         );
     };
     // Just required fields and a custom scheduler backend without trailing comma.
@@ -287,7 +287,7 @@ macro_rules! beat {
         $crate::__beat_internal!(
             $crate::broker::AMQPBroker { $broker_url },
             [ $( $pattern => $queue ),* ],
-            $crate::DummyBackend::new(),
+            $crate::beat::LocalSchedulerBackend::new(),
             $( $x = $y, )*
         );
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types.
+//! All error types used through the library.
 
 use chrono::{DateTime, Utc};
 use failure::{Context, Fail};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,7 @@
 mod app;
 mod routing;
 pub use app::{Celery, CeleryBuilder};
-mod beat;
-pub use beat::{
-    Beat, BeatBuilder, DummyBackend, RegularSchedule, Schedule, ScheduledTask, SchedulerBackend,
-};
+pub mod beat;
 pub mod broker;
 pub mod error;
 pub use error::TaskResultExt;


### PR DESCRIPTION
- `beat` module made public.
- `DummyBackend` renamed to `LocalSchedulerBackend`.