### PR TITLE
drop direct dependency on amq-protocol and cookie-factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Now using `tokio-amqp` internally with `lapin`.
+- Drop explicit dependency on amq-protocol
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ thiserror = "1.0"
 async-trait = "0.1"
 lapin = "1.2.7"
 tokio-amqp = "0.1.3"
-amq-protocol = "=6.0.0-rc12"
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}
@@ -45,10 +44,6 @@ celery-codegen = { version = "0.4.0-rc4", path = "./celery-codegen", optional = 
 colored = "2"
 once_cell = { version = "1.3.1", optional = true }
 globset = "0.4"
-# This is only used by amqp-protocol. We need to pin to this version to avoid a compilation error
-# where building on nightly Rust.
-# TODO (epwalsh): is this still needed?
-cookie-factory = "0.3.1"
 hostname = "0.3.0"
 
 [dev-dependencies]

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -1,16 +1,13 @@
 //! AMQP broker.
 
-use amq_protocol::{
-    types::{AMQPValue, FieldArray},
-    uri::{self, AMQPUri},
-};
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
 use lapin::message::Delivery;
 use lapin::options::{
     BasicAckOptions, BasicConsumeOptions, BasicPublishOptions, BasicQosOptions, QueueDeclareOptions,
 };
-use lapin::types::FieldTable;
+use lapin::types::{AMQPValue, FieldArray, FieldTable};
+use lapin::uri::{self, AMQPUri};
 use lapin::{BasicProperties, Channel, Connection, ConnectionProperties, Queue};
 use log::debug;
 use std::collections::HashMap;


### PR DESCRIPTION
lapin already reexports everything that is needed