### PR TITLE
Fix a bug which caused a delayed task to be dropped without being executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Task ID now logged when a beat app sends a task.
 - Fixes to docs. Added a "Build Docs" job to GitHub Actions.
+- Fixed a Celery beat [issue](https://github.com/rusty-celery/rusty-celery/issues/199)
+  that caused a task to be dropped if its scheduled run was delayed
 
 ## v0.4.0-rc4 - 2020-09-16
 

--- a/src/beat/tests.rs
+++ b/src/beat/tests.rs
@@ -3,7 +3,6 @@
 ///
 /// Errors in the order of 1-2 milliseconds are expected, so checks
 /// are written to have a tolerance of at least 10 milliseconds.
-
 use super::*;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -141,7 +140,7 @@ async fn test_task_with_delayed_first_run() {
     // if it was not scheduled to run immediately. Hence here we check that
     // the task has been executed at least once.
     assert!(
-        tasks.len() > 0,
+        !tasks.is_empty(),
         "A task that was supposed to run at least once did not run."
     );
 }


### PR DESCRIPTION
As @dmitryvm1 described in [this issue](https://github.com/rusty-celery/rusty-celery/issues/199), if the next task was not due for execution when `tick` was called on the scheduler the task would be dropped without being executed.

This PR changes the logic of `tick`: now we pop a task only after checking that its execution is due, otherwise we just wait.

A regression test has been added to verify the fix.