### PR TITLE
Add the max_sleep_duration property to the Beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added the `max_sleep_duration` property on the `Beat` which can be used to ensure that
+  the scheduler backend is called regularly (which may be necessary for custom backends).
+
 ## [v0.4.0-rc5](https://github.com/rusty-celery/rusty-celery/releases/tag/v0.4.0-rc5) - 2020-11-19
 
 ### Added

--- a/src/beat/scheduler.rs
+++ b/src/beat/scheduler.rs
@@ -4,6 +4,8 @@ use log::{debug, info};
 use std::collections::BinaryHeap;
 use std::time::{Duration, SystemTime};
 
+const DEFAULT_SLEEP_INTERVAL: Duration = Duration::from_millis(500);
+
 /// A [`Scheduler`] is in charge of executing scheduled tasks when they are due.
 ///
 /// It is somehow similar to a future, in the sense that by itself it does nothing,
@@ -26,7 +28,7 @@ where
     pub fn new(broker: B) -> Scheduler<B> {
         Scheduler {
             heap: BinaryHeap::new(),
-            default_sleep_interval: Duration::from_millis(500),
+            default_sleep_interval: DEFAULT_SLEEP_INTERVAL,
             broker,
         }
     }


### PR DESCRIPTION
As it is now it is not really possible to write custom scheduler backends because the backend is only called if there is a task scheduled to run. This PR adds the possibility to set a maximum sleeping time for the beat to ensure that the backend is called regularly.

Do you think this can make it on time for this release?