### PR TITLE
Rename RegularSchedule to DeltaSchedule in the beat module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- ⚠️ **BREAKING CHANGE** ⚠️
+
+  The `RegularSchedule` in the `beat` module has been renamed to `DeltaSchedule` to
+  be more coherent with Python Celery terminology, where it is sometimes called *timedelta*.
+
 ### Added
 
 - 🚀🚀 Redis broker support 🚀🚀

--- a/examples/beat_app.rs
+++ b/examples/beat_app.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)]
 
 use anyhow::Result;
-use celery::beat::{CronSchedule, RegularSchedule};
+use celery::beat::{CronSchedule, DeltaSchedule};
 use celery::broker::AMQPBroker;
 use celery::task::TaskResult;
 use env_logger::Env;
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     ).await?;
 
     // Add scheduled tasks to the default `Beat` and start it.
-    let add_schedule = RegularSchedule::new(Duration::from_secs(5));
+    let add_schedule = DeltaSchedule::new(Duration::from_secs(5));
     beat.schedule_task(add::new(1, 2), add_schedule);
 
     // The long running task will run every two minutes.

--- a/src/beat/mod.rs
+++ b/src/beat/mod.rs
@@ -39,7 +39,7 @@ mod backend;
 pub use backend::{LocalSchedulerBackend, SchedulerBackend};
 
 mod schedule;
-pub use schedule::{CronSchedule, RegularSchedule, Schedule};
+pub use schedule::{CronSchedule, DeltaSchedule, Schedule};
 
 mod scheduled_task;
 pub use scheduled_task::ScheduledTask;

--- a/src/beat/schedule/mod.rs
+++ b/src/beat/schedule/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains the definition of application-provided schedules.
 //!
 //! These structs have not changed a lot compared to Python: in Python there are three
-//! different types of schedules: `schedule` (corresponding to [`RegularSchedule`]),
+//! different types of schedules: `schedule` (corresponding to [`DeltaSchedule`]),
 //! `crontab` (corresponding to [`CronSchedule`]), `solar` (not implemented yet).
 use std::time::{Duration, SystemTime};
 
@@ -18,20 +18,20 @@ pub trait Schedule {
 }
 
 /// A schedule that can be used to execute tasks at regular intervals.
-pub struct RegularSchedule {
+pub struct DeltaSchedule {
     interval: Duration,
 }
 
-impl RegularSchedule {
-    /// Create a new regular schedule which can be used to execute a task
+impl DeltaSchedule {
+    /// Create a new time delta schedule which can be used to execute a task
     /// forever, starting immediately and with the given `interval`
     /// between subsequent executions.
-    pub fn new(interval: Duration) -> RegularSchedule {
-        RegularSchedule { interval }
+    pub fn new(interval: Duration) -> DeltaSchedule {
+        DeltaSchedule { interval }
     }
 }
 
-impl Schedule for RegularSchedule {
+impl Schedule for DeltaSchedule {
     fn next_call_at(&self, last_run_at: Option<SystemTime>) -> Option<SystemTime> {
         match last_run_at {
             Some(last_run_at) => Some(

--- a/src/beat/tests.rs
+++ b/src/beat/tests.rs
@@ -18,7 +18,7 @@ use tokio::time::{self, Duration};
 /// the correct amount of times. We also check that executions are
 /// reasonably on time.
 #[tokio::test]
-async fn test_task_with_regular_schedule() {
+async fn test_task_with_delta_schedule() {
     // Create a dummy broker for this test.
     let dummy_broker = MockBroker::new();
 
@@ -41,7 +41,7 @@ async fn test_task_with_regular_schedule() {
 
     beat.schedule_task(
         Signature::<DummyTask>::new(()),
-        RegularSchedule::new(Duration::from_millis(20)),
+        DeltaSchedule::new(Duration::from_millis(20)),
     );
 
     let start_time = SystemTime::now();
@@ -104,11 +104,11 @@ async fn test_scheduling_two_tasks() {
 
     beat.schedule_task(
         Signature::<DummyTask>::new(()),
-        RegularSchedule::new(Duration::from_millis(60)),
+        DeltaSchedule::new(Duration::from_millis(60)),
     );
     beat.schedule_task(
         Signature::<DummyTask2>::new(()),
-        RegularSchedule::new(Duration::from_millis(43)),
+        DeltaSchedule::new(Duration::from_millis(43)),
     );
 
     let result = time::timeout(Duration::from_millis(200), beat.start()).await;


### PR DESCRIPTION
Hi @epwalsh, I've been quite busy recently so I had no time to work at the `beat` macro : (

In the meanwhile I have refactored `RegularSchedule`, so that at least this is done before the release. I have chosen `DeltaSchedule` as name because it's shorter than `TimedeltaSchedule`, but I have no strong preference. Please let me know if you would rather go with something else.