### PR TITLE
fix bug closing AMQP connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🚀🚀 Redis broker support 🚀🚀
 - Added the `max_sleep_duration` property on the `Beat` which can be used to ensure that
   the scheduler backend is called regularly (which may be necessary for custom backends).
+- Added a method `Broker::cancel` to cancel an existing consumer.
+- Changed `Ok` variant type of the the return type of `Broker::consume`. This is now a tuple that includes a unique
+  consumer tag that can then be passed to `Broker::cancel` to cancel the corresponding consumer.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `max_sleep_duration` property on the `Beat` which can be used to ensure that
   the scheduler backend is called regularly (which may be necessary for custom backends).
 
+### Fixed
+
+- Fixed a bug with `AMQPBroker::close()` that would result in an error with `lapin`.
+
 ## [v0.4.0-rc5](https://github.com/rusty-celery/rusty-celery/releases/tag/v0.4.0-rc5) - 2020-11-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = { version = "0.8", optional = true }
 serde-pickle = { version = "0.6", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
-lapin = "1.2.7"
+lapin = "1.6.2"
 tokio-amqp = "0.3.0"
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = { version = "0.8", optional = true }
 serde-pickle = { version = "0.6", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
-lapin = "1.6.3"
+lapin = "1.6.5"
 tokio-amqp = "0.3.1"
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = { version = "0.8", optional = true }
 serde-pickle = { version = "0.6", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
-lapin = "1.6.2"
+lapin = "1.6.3"
 tokio-amqp = "0.3.1"
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "celery_app"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "0.3.4", features = ["full"]}
+tokio = { version = "0.3.6", features = ["full"]}
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 rmp-serde = { version = "0.15", optional = true }
@@ -35,7 +35,7 @@ serde-pickle = { version = "0.6", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
 lapin = "1.6.2"
-tokio-amqp = "0.3.0"
+tokio-amqp = "0.3.1"
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -645,6 +645,8 @@ where
             self.broker.cancel(&consumer_tag).await?;
         }
 
+        drop(stream_map);
+
         if pending_tasks > 0 {
             // Warm shutdown loop. When there are still pendings tasks we wait for them
             // to finish. We get updates about pending tasks through the `task_event_rx` channel.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -565,8 +565,8 @@ where
                         .consume(
                             queue,
                             Box::new(move |e| {
-                                if broker_error_tx.clone().try_send(e).is_err() {
-                                    error!("Failed to send broker error event");
+                                if let Err(err) = broker_error_tx.clone().try_send(e) {
+                                    error!("Failed to send broker error event: {:?}", err);
                                 };
                             }),
                         )

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -572,9 +572,7 @@ where
                             queue,
                             &consumer_tag,
                             Box::new(move |e| {
-                                if let Err(err) = broker_error_tx.clone().try_send(e) {
-                                    error!("Failed to send broker error event: {:?}", err);
-                                };
+                                broker_error_tx.clone().try_send(e).ok();
                             }),
                         )
                         .await?,
@@ -644,8 +642,6 @@ where
             debug!("Cancelling consumer {}", consumer_tag);
             self.broker.cancel(&consumer_tag).await?;
         }
-
-        drop(stream_map);
 
         if pending_tasks > 0 {
             // Warm shutdown loop. When there are still pendings tasks we wait for them

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -316,13 +316,13 @@ impl Broker for AMQPBroker {
         let conn = self.conn.lock().await;
 
         if conn.status().connected() {
-            debug!("Closing all channels and connections...");
             // 320 reply-code = "connection-forced", operator intervened.
             // For reference see https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.reply-code
             debug!("Closing consumer channel...");
             consume_channel.close(320, "").await?;
             debug!("Closing producer channel...");
             produce_channel.close(320, "").await?;
+            debug!("Closing connection...");
             conn.close(320, "").await?;
         }
 

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -315,11 +315,17 @@ impl Broker for AMQPBroker {
         let produce_channel = self.produce_channel.write().await;
         let conn = self.conn.lock().await;
 
-        if conn.status().connected() {
+        if consume_channel.status().connected() {
             debug!("Closing consumer channel...");
             consume_channel.close(200, "OK").await?;
+        }
+
+        if produce_channel.status().connected() {
             debug!("Closing producer channel...");
             produce_channel.close(200, "OK").await?;
+        }
+
+        if conn.status().connected() {
             debug!("Closing connection...");
             conn.close(200, "OK").await?;
         }

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -316,14 +316,12 @@ impl Broker for AMQPBroker {
         let conn = self.conn.lock().await;
 
         if conn.status().connected() {
-            // 320 reply-code = "connection-forced", operator intervened.
-            // For reference see https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.reply-code
             debug!("Closing consumer channel...");
-            consume_channel.close(320, "").await?;
+            consume_channel.close(200, "OK").await?;
             debug!("Closing producer channel...");
-            produce_channel.close(320, "").await?;
+            produce_channel.close(200, "OK").await?;
             debug!("Closing connection...");
-            conn.close(320, "").await?;
+            conn.close(200, "OK").await?;
         }
 
         Ok(())

--- a/src/broker/mock.rs
+++ b/src/broker/mock.rs
@@ -79,9 +79,15 @@ impl Broker for MockBroker {
     async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
         &self,
         queue: &str,
+        consumer_tag: &str,
         error_handler: Box<E>,
     ) -> Result<Self::DeliveryStream, BrokerError> {
         unimplemented!();
+    }
+
+    #[allow(unused)]
+    async fn cancel(&self, consumer_tag: &str) -> Result<(), BrokerError> {
+        Ok(())
     }
 
     #[allow(unused)]

--- a/src/broker/mock.rs
+++ b/src/broker/mock.rs
@@ -79,9 +79,8 @@ impl Broker for MockBroker {
     async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
         &self,
         queue: &str,
-        consumer_tag: &str,
         error_handler: Box<E>,
-    ) -> Result<Self::DeliveryStream, BrokerError> {
+    ) -> Result<(String, Self::DeliveryStream), BrokerError> {
         unimplemented!();
     }
 

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -47,7 +47,8 @@ pub trait Broker: Send + Sync + Sized {
 
     /// Consume messages from a queue.
     ///
-    /// If the connection is successful, this should return a future stream of `Result`s where an `Ok`
+    /// If the connection is successful, this should return a unique consumer tag and a
+    /// corresponding stream of `Result`s where an `Ok`
     /// value is a [`Self::Delivery`](trait.Broker.html#associatedtype.Delivery)
     /// type that can be coerced into a [`Message`](protocol/struct.Message.html)
     /// and an `Err` value is a
@@ -55,9 +56,8 @@ pub trait Broker: Send + Sync + Sized {
     async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
         &self,
         queue: &str,
-        consumer_tag: &str,
         error_handler: Box<E>,
-    ) -> Result<Self::DeliveryStream, BrokerError>;
+    ) -> Result<(String, Self::DeliveryStream), BrokerError>;
 
     /// Cancel the consumer with the given `consumer_tag`.
     async fn cancel(&self, consumer_tag: &str) -> Result<(), BrokerError>;

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -55,8 +55,12 @@ pub trait Broker: Send + Sync + Sized {
     async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
         &self,
         queue: &str,
+        consumer_tag: &str,
         error_handler: Box<E>,
     ) -> Result<Self::DeliveryStream, BrokerError>;
+
+    /// Cancel the consumer with the given `consumer_tag`.
+    async fn cancel(&self, consumer_tag: &str) -> Result<(), BrokerError>;
 
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.
     async fn ack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError>;

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -280,6 +280,7 @@ impl Broker for RedisBroker {
     async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
         &self,
         queue: &str,
+        _consumer_tag: &str,
         error_handler: Box<E>,
     ) -> Result<Self::DeliveryStream, BrokerError> {
         let consumer = Consumer {
@@ -294,6 +295,10 @@ impl Broker for RedisBroker {
             waker_tx: self.waker_tx.clone(),
         };
         Ok(consumer)
+    }
+
+    async fn cancel(&self, _consumer_tag: &str) -> Result<(), BrokerError> {
+        Ok(())
     }
 
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.


### PR DESCRIPTION
Potential fix for #213.

Cancelling the consumer channel before closing seems to fix this issue. But I'm not sure if this is really necessary and if this is actually addressing the issue rather than the symptoms, because I tried a few other trivial things that also prevented this error, such as briefly sleeping (`tokio::time::sleep(Duration::from_millis(100)).await`) before closing.

@Keruspe do you know where this error stems from? And is this the proper way to close channels and connections?