### PR TITLE
Use redis@0.18.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The `RegularSchedule` in the `beat` module has been renamed to `DeltaSchedule` to
   be more coherent with Python Celery terminology, where it is sometimes called *timedelta*.
+- `redis` dependency updated to 0.18.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,7 @@ globset = "0.4"
 hostname = "0.3.0"
 
 [dependencies.redis]
-git = "https://github.com/mitsuhiko/redis-rs.git"
-rev="8088a59"
+version = "0.18"
 features=["connection-manager", "tokio-comp"]
 
 [dev-dependencies]


### PR DESCRIPTION
I saw the commit related to holding up a RC release here waiting on redis release which has evidently happened.

https://github.com/mitsuhiko/redis-rs/blob/master/CHANGELOG.md#0180-2020-12-03