### PR TITLE
Modify the beat macro to accept a list of tasks to schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The `RegularSchedule` in the `beat` module has been renamed to `DeltaSchedule` to
   be more coherent with Python Celery terminology, where it is sometimes called *timedelta*.
+- Tokio updated to 1.0.0.
+- The `Broker::configure_task_routes` produces `BrokerError` instead of `CeleryError`.
+- The `beat` macro now expects a list of tasks that is used to initialize the scheduler.
+- Errors have been refactored:
+   * The `BadRoutingPattern` variant has been moved from `CeleryError` to `BrokerError`;
+   * The `CronScheduleError` has been replaced by a `ScheduleError` enum with a `CronScheduleError` variant;
+   * A `ScheduleError` variant has been added to `BeatError`
+   * A `BadRoutingPattern` error has been added.
 
 ### Added
 
 - 🚀🚀 Redis broker support 🚀🚀
 - Added the `max_sleep_duration` property on the `Beat` which can be used to ensure that
   the scheduler backend is called regularly (which may be necessary for custom backends).
+- Added a method `Beat::schedule_named_task` to add a scheduled task with a custom name.
 - Added a method `Broker::cancel` to cancel an existing consumer.
 - Changed `Ok` variant type of the the return type of `Broker::consume`. This is now a tuple that includes a unique
   consumer tag that can then be passed to `Broker::cancel` to cancel the corresponding consumer.
 - Added a "coverage" job to GitHub Actions.
-
-### Changed
-
-- Tokio updated to 1.0.0.
 
 ### Fixed
 

--- a/src/beat/schedule/cron/parsing.rs
+++ b/src/beat/schedule/cron/parsing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::{Ordinal, TimeUnitField};
-use crate::error::CronScheduleError;
+use crate::error::ScheduleError;
 
 pub struct CronParsingError;
 
@@ -13,7 +13,7 @@ pub enum Shorthand {
     Hourly,
 }
 
-pub fn parse_shorthand(s: &str) -> Result<Shorthand, CronScheduleError> {
+pub fn parse_shorthand(s: &str) -> Result<Shorthand, ScheduleError> {
     use Shorthand::*;
     match s.to_lowercase().as_str() {
         "@yearly" => Ok(Yearly),
@@ -21,7 +21,7 @@ pub fn parse_shorthand(s: &str) -> Result<Shorthand, CronScheduleError> {
         "@weekly" => Ok(Weekly),
         "@daily" => Ok(Daily),
         "@hourly" => Ok(Hourly),
-        _ => Err(CronScheduleError(format!(
+        _ => Err(ScheduleError::CronScheduleError(format!(
             "'{}' is not a valid shorthand for a cron schedule",
             s
         ))),
@@ -45,7 +45,7 @@ enum ParsedElement {
     }, // inclusive
 }
 
-pub fn parse_longhand<T: TimeUnitField>(s: &str) -> Result<Vec<Ordinal>, CronScheduleError> {
+pub fn parse_longhand<T: TimeUnitField>(s: &str) -> Result<Vec<Ordinal>, ScheduleError> {
     let lower_bound = T::inclusive_min();
     let upper_bound = T::inclusive_max();
     let mut result = HashSet::new();
@@ -56,7 +56,7 @@ pub fn parse_longhand<T: TimeUnitField>(s: &str) -> Result<Vec<Ordinal>, CronSch
         match parsed_element {
             Err(_) => {
                 let error_message = format!("'{}' is an invalid value for {}", s, T::name());
-                return Err(CronScheduleError(error_message));
+                return Err(ScheduleError::CronScheduleError(error_message));
             }
             Ok(Star) => {
                 for i in lower_bound..=upper_bound {
@@ -134,7 +134,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse() -> Result<(), CronScheduleError> {
+    fn test_parse() -> Result<(), ScheduleError> {
         assert_eq!(parse_longhand::<Minutes>("3")?, vec![3]);
         assert_eq!(parse_longhand::<Minutes>("3-6/2")?, vec![3, 5]);
         assert_eq!(parse_longhand::<Months>("*/3")?, vec![1, 4, 7, 10]);

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -7,7 +7,7 @@ use futures::Stream;
 use log::error;
 use tokio::time::{self, Duration};
 
-use crate::error::{BrokerError, CeleryError};
+use crate::error::BrokerError;
 use crate::{
     protocol::{Message, TryDeserializeMessage},
     routing::Rule,
@@ -117,7 +117,7 @@ pub trait BrokerBuilder {
 pub(crate) fn configure_task_routes<Bb: BrokerBuilder>(
     mut broker_builder: Bb,
     task_routes: &[(String, String)],
-) -> Result<(Bb, Vec<Rule>), CeleryError> {
+) -> Result<(Bb, Vec<Rule>), BrokerError> {
     let mut rules: Vec<Rule> = Vec::with_capacity(task_routes.len());
     for (pattern, queue) in task_routes {
         let rule = Rule::new(&pattern, &queue)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,6 @@ pub enum CeleryError {
     #[error("protocol error")]
     ProtocolError(#[from] ProtocolError),
 
-    /// An invalid glob pattern for a routing rule.
-    #[error("invalid glob routing rule")]
-    BadRoutingPattern(#[from] globset::Error),
-
     /// There is already a task registerd to this name.
     #[error("there is already a task registered as '{0}'")]
     TaskRegistrationError(String),
@@ -49,12 +45,19 @@ pub enum BeatError {
     /// A protocol error.
     #[error("protocol error")]
     ProtocolError(#[from] ProtocolError),
+
+    /// An error with a task schedule.
+    #[error("task schedule error")]
+    ScheduleError(#[from] ScheduleError),
 }
 
-/// Error that can occur while creating a cron schedule.
+/// Errors that are related to task schedules.
 #[derive(Error, Debug)]
-#[error("invalid cron schedule: {0}")]
-pub struct CronScheduleError(pub String);
+pub enum ScheduleError {
+    /// Error that can occur while creating a cron schedule.
+    #[error("invalid cron schedule: {0}")]
+    CronScheduleError(String),
+}
 
 /// Errors that can occur at the task level.
 #[derive(Error, Debug)]
@@ -141,6 +144,10 @@ pub enum BrokerError {
     #[error("Deserialize error \"{0}\"")]
     DeserializeError(#[from] serde_json::Error),
 
+    /// Routing pattern error
+    #[error("Routing pattern error \"{0}\"")]
+    BadRoutingPattern(#[from] BadRoutingPattern),
+
     /// Protocol error
     #[error("Protocol error \"{0}\"")]
     ProtocolError(#[from] ProtocolError),
@@ -170,6 +177,11 @@ impl BrokerError {
         }
     }
 }
+
+/// An invalid glob pattern for a routing rule.
+#[derive(Error, Debug)]
+#[error("invalid glob routing rule")]
+pub struct BadRoutingPattern(#[from] globset::Error);
 
 /// Errors that can occur due to messages not conforming to the protocol.
 #[derive(Error, Debug)]

--- a/src/export.rs
+++ b/src/export.rs
@@ -3,3 +3,4 @@ pub use crate::serde::{Deserialize, Serialize};
 pub use crate::tokio::runtime::Runtime;
 pub use std::sync::Arc;
 pub type Result<T> = std::result::Result<T, crate::error::CeleryError>;
+pub type BeatResult<T> = std::result::Result<T, crate::error::BeatError>;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,6 +1,6 @@
 use globset::{Glob, GlobMatcher};
 
-use crate::error::CeleryError;
+use crate::error::BadRoutingPattern;
 
 /// A rule for routing tasks to a queue based on a glob pattern.
 pub(crate) struct Rule {
@@ -9,7 +9,7 @@ pub(crate) struct Rule {
 }
 
 impl Rule {
-    pub(crate) fn new(pattern: &str, queue: &str) -> Result<Self, CeleryError> {
+    pub(crate) fn new(pattern: &str, queue: &str) -> Result<Self, BadRoutingPattern> {
         Ok(Self {
             pattern: Glob::new(pattern)?.compile_matcher(),
             queue: queue.into(),

--- a/tests/beat_codegen/mod.rs
+++ b/tests/beat_codegen/mod.rs
@@ -4,6 +4,7 @@ use celery::prelude::*;
 async fn test_basic_use() {
     let _beat = celery::beat!(
         broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+        tasks = [],
         task_routes = []
     );
 }
@@ -12,6 +13,7 @@ async fn test_basic_use() {
 async fn test_basic_use_with_trailing_comma() {
     let _beat = celery::beat!(
         broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+        tasks = [],
         task_routes = [],
     );
 }
@@ -20,6 +22,7 @@ async fn test_basic_use_with_trailing_comma() {
 async fn test_with_options() {
     let _beat = celery::beat!(
         broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+        tasks = [],
         task_routes = [],
         default_queue = "celery"
     );
@@ -29,7 +32,17 @@ async fn test_with_options() {
 async fn test_with_options_and_trailing_comma() {
     let _beat = celery::beat!(
         broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+        tasks = [],
         task_routes = [],
         default_queue = "celery",
+    );
+}
+
+#[tokio::test]
+async fn test_tasks_and_task_routes_with_trailing_comma() {
+    let _beat = celery::beat!(
+        broker = AMQPBroker { std::env::var("AMQP_ADDR").unwrap() },
+        tasks = [,],
+        task_routes = [,],
     );
 }


### PR DESCRIPTION
## Chosen API

The implemented API is the following:

```rust
tasks = [
    "add" => {
        add,
        schedule = DeltaSchedule::new(Duration::from_secs(5)),
        args = (1, 2),
    },
    "long_running" => {
        long_running_task,
        schedule = CronSchedule::from_string("*/2 * * * *")?,
        args = (Some(1),),
    }
],
```

The `tasks` array is right before the `task_routes` array, as in the `app` macro.

## Comments

The modification to the `beat` macro unearthed a few problems that needed to be addressed.

First of all, the `CronScheduleError` was a standalone error, but it
is more useful to make it part of the `BeatError` family, so that
users may expect only one type of error when using the beat module.
This is also needed by our macro, that internally creates a function
which should return only one type of error (i.e., `BeatError`).

Another problem was that the `BeatBuilder`'s build method
produced a `CeleryError` instead of a `BeatError`, which was weird.
This was due to the call to `configure_task_routes` on the broker,
which in turn calls `Rule::new`.

There is no specific reason why `Rule::new` should produce a
`CeleryError`, so it now produces a `BadRoutingPattern` error which is
convertible to `BrokerError` which is convertible to both
`CeleryError` and `BeatError`.

Of course these are breaking changes, what do you think about this @epwalsh ?

## Other changes

- Another API change is the addition of `schedule_named_task` on the `Beat` struct. Compared to `schedule_task`, this method accepts a custom name instead of using the task name. I'm not sure about the method name, are there other suggestions?
- I have used intra doc links for the `beat` macro documentation. Is this alright? (for reference, it landed on stable with Rust 1.48.0)