### PR TITLE
Add code coverage check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,50 @@ jobs:
         command: test
         args: --no-run --test codegen beat_codegen
 
+  coverage:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      rabbitmq:
+        image: rabbitmq
+        ports:
+          - 5672:5672
+        env:
+          RABBITMQ_DEFAULT_VHOST: my_vhost
+    steps:
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+
+    - uses: actions/checkout@v2
+
+    - name: Ready cache
+      run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
+
+    - name: Cache cargo
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Run cargo-tarpaulin
+      uses: actions-rs/tarpaulin@v0.1
+      with:
+        out-type: Lcov
+        args: '--all-features --workspace'
+
+    - name: Coveralls upload
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: "lcov.info"
+
   docs:
     name: Build Docs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         args: --no-run --test codegen beat_codegen
 
   coverage:
+    name: Coverage
     runs-on: ubuntu-latest
     services:
       redis:
@@ -221,15 +222,24 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Ready cache
-      run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
+    - name: Set build variables
+      shell: bash
+      run: |
+        # We use these variables as part of the cache keys.
+        echo "RUST_VERSION=$(rustc --version)" >> $GITHUB_ENV
+        echo "DOY=$(date +%j)" >> $GITHUB_ENV
 
-    - name: Cache cargo
-      uses: actions/cache@v1
-      id: cache
+    - name: Cache cargo registry
+      uses: actions/cache@v2
       with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        path: ~/.cargo/registry
+        key: cargo registry ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ hashFiles('**/Cargo.toml') }} ${{ env.DOY }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: cargo build ${{ github.job }} ${{ runner.os }} ${{ env.RUST_VERSION }} ${{ hashFiles('**/Cargo.toml') }} ${{ env.DOY }}
 
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         out-type: Lcov
-        args: '--all-features --workspace'
+        args: '--all-features --workspace --ignore-tests'
 
     - name: Coveralls upload
       uses: coverallsapp/github-action@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a method `Broker::cancel` to cancel an existing consumer.
 - Changed `Ok` variant type of the the return type of `Broker::consume`. This is now a tuple that includes a unique
   consumer tag that can then be passed to `Broker::cancel` to cancel the corresponding consumer.
+- Added a "coverage" job to GitHub Actions.
 
 ### Changed
 


### PR DESCRIPTION
Closes #175

The code coverage is done with tarpaulin, I added an step to upload the reports to coveralls, you can see the current output of that report in: https://coveralls.io/github/rusty-celery/rusty-celery, let me know if you prefer to upload them into another place like codecov.


I also fixed the clippy warnings