### PR TITLE
Move amqp and redis support behind feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ serde_yaml = { version = "0.8", optional = true }
 serde-pickle = { version = "0.6", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
-lapin = "1.6.5"
-tokio-amqp = "1.0.0"
+lapin = { version = "1.6.5", optional = true }
+tokio-amqp = { version = "1.0.0", optional = true }
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }
 uuid = { version = "0.8", features = ["v4"]}
@@ -48,7 +48,7 @@ once_cell = { version = "1.3.1" }
 globset = "0.4"
 hostname = "0.3.0"
 
-redis = { version="0.20.0", features=["connection-manager", "tokio-comp"] }
+redis = { version="0.20.0", features=["connection-manager", "tokio-comp"], optional = true }
 
 [dev-dependencies]
 rmp-serde = "0.15"
@@ -60,6 +60,7 @@ anyhow = "1.0"
 structopt = "0.3"
 
 [features]
-default = ["codegen"]
+default = ["codegen", "amqp", "redis"]
+amqp = ["lapin", "tokio-amqp"]
 codegen = ["celery-codegen"]
 extra_content_types = ["rmp-serde", "rmpv", "serde_yaml", "serde-pickle"]

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -13,9 +13,14 @@ use crate::{
     routing::Rule,
 };
 
+#[cfg(feature = "amqp")]
 mod amqp;
+#[cfg(feature = "redis")]
 mod redis;
+
+#[cfg(feature = "redis")]
 pub use self::redis::{RedisBroker, RedisBrokerBuilder};
+#[cfg(feature = "amqp")]
 pub use amqp::{AMQPBroker, AMQPBrokerBuilder};
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,10 +153,12 @@ pub enum BrokerError {
     ProtocolError(#[from] ProtocolError),
 
     /// Any other AMQP error that could happen.
+    #[cfg(feature = "amqp")]
     #[error("AMQP error \"{0}\"")]
     AMQPError(#[from] lapin::Error),
 
     /// Any other Redis error that could happen.
+    #[cfg(feature = "redis")]
     #[error("Redis error \"{0}\"")]
     RedisError(#[from] redis::RedisError),
 }
@@ -165,12 +167,14 @@ impl BrokerError {
     pub fn is_connection_error(&self) -> bool {
         match self {
             BrokerError::IoError(_) | BrokerError::NotConnected => true,
+            #[cfg(feature = "amqp")]
             BrokerError::AMQPError(err) => matches!(
                 err,
                 lapin::Error::ProtocolError(_)
                     | lapin::Error::InvalidConnectionState(_)
                     | lapin::Error::InvalidChannelState(_)
             ),
+            #[cfg(feature = "redis")]
             BrokerError::RedisError(err) => {
                 err.is_connection_dropped() || err.is_connection_refusal()
             }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,8 @@
 //! A "prelude" for users of the `celery` crate.
 
-pub use crate::broker::{AMQPBroker, RedisBroker};
+#[cfg(feature = "amqp")]
+pub use crate::broker::AMQPBroker;
+#[cfg(feature = "redis")]
+pub use crate::broker::RedisBroker;
 pub use crate::error::*;
 pub use crate::task::{Task, TaskResult, TaskResultExt};

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -452,8 +452,8 @@ impl Message {
                 "correlation_id": self.properties.correlation_id.clone(),
                 "reply_to": reply_to,
                 "delivery_tag": delivery_tag,
-                "body_encoding": "base64",
-            })
+                "body_encoding": "base64"
+            }),
         });
         let res = serde_json::to_string(&msg_json_value)?;
         Ok(res.into_bytes())


### PR DESCRIPTION
This adds feature flags `redis` and `amqp` to only compile code and dependencies for the brokers being used.

Witt this patch, you can disable the default features and then only enable either the `redis` or the `amqp` feature to not include deps on an unused broker: 
```toml
celery = { version = "0.4.0-rc6", default_features = false, features = ["redis", "codegen"] }
``` 

The PR should be a non-breaking change because I left the default to include both redis and amqp support. When releasing a new major version, I'd propose to change this to not include any broker impls by default and to require to enable one of the features.
