### PR TITLE
feat(error): derive Serialize, Deserialize for TaskError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! All error types used throughout the library.
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors that can occur while creating or using a `Celery` app.
@@ -60,7 +61,7 @@ pub enum ScheduleError {
 }
 
 /// Errors that can occur at the task level.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize)]
 pub enum TaskError {
     /// An error that is expected to happen every once in a while.
     ///


### PR DESCRIPTION
I'm implementing a custom task result store, while rusty-celery lacks task result backends.

For this, it's useful to store `TaskError` values: this change adds serde derives for that.

(This might also be useful for rusty-celery's planned result backend work.)