### PR TITLE
Broker agnostic Celery type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Changed Celery type to be broker agnostic, allowing broker to be chosen dynamically at runtime
+
 ## [v0.4.0](https://github.com/rusty-celery/rusty-celery/releases/tag/v0.4.0) - 2023-02-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Changed Celery type to be broker agnostic, allowing broker to be chosen dynamically at runtime
+### Changed
+
+- Changed Celery type to be broker agnostic, allowing broker to be chosen dynamically at runtime.
 
 ## [v0.4.0](https://github.com/rusty-celery/rusty-celery/releases/tag/v0.4.0) - 2023-02-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hostname = "0.3.0"
 redis = { version = "0.21.1", features=["connection-manager", "tokio-comp"] }
 tokio-executor-trait = "2.1.0"
 tokio-reactor-trait = "1.1.0"
+futures-lite = "1.12.0"
 
 [dev-dependencies]
 rmp-serde = "0.15"

--- a/examples/beat_app.rs
+++ b/examples/beat_app.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Result;
 use celery::beat::{CronSchedule, DeltaSchedule};
-use celery::broker::AMQPBroker;
 use celery::task::TaskResult;
 use env_logger::Env;
 use tokio::time::Duration;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,15 +17,17 @@ use tokio_stream::StreamMap;
 
 mod trace;
 
-use crate::broker::{build_and_connect, configure_task_routes, broker_builder_from_url, Delivery, Broker, BrokerBuilder};
+use crate::broker::{
+    broker_builder_from_url, build_and_connect, configure_task_routes, Broker, BrokerBuilder,
+    Delivery,
+};
 use crate::error::{BrokerError, CeleryError, TraceError};
 use crate::protocol::{Message, MessageContentType};
 use crate::routing::Rule;
 use crate::task::{AsyncResult, Signature, Task, TaskEvent, TaskOptions, TaskStatus};
 use trace::{build_tracer, TraceBuilder, TracerTrait};
 
-struct Config
-{
+struct Config {
     name: String,
     hostname: String,
     broker_builder: Box<dyn BrokerBuilder>,
@@ -39,13 +41,11 @@ struct Config
 }
 
 /// Used to create a [`Celery`] app with a custom configuration.
-pub struct CeleryBuilder
-{
+pub struct CeleryBuilder {
     config: Config,
 }
 
-impl CeleryBuilder
-{
+impl CeleryBuilder {
     /// Get a [`CeleryBuilder`] for creating a [`Celery`] app with a custom configuration.
     pub fn new(name: &str, broker_url: &str) -> Self {
         Self {
@@ -259,8 +259,7 @@ pub struct Celery {
     broker_connection_retry_delay: u32,
 }
 
-impl Celery
-{
+impl Celery {
     /// Print a pretty ASCII art logo and configuration settings.
     ///
     /// This is useful and fun to print from a worker application right after

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,5 +1,4 @@
-use super::Celery;
-use crate::broker::mock::MockBroker;
+use super::{Celery, CeleryBuilder};
 use crate::protocol::MessageContentType;
 use crate::task::{Request, Signature, Task, TaskOptions, TaskResult};
 use async_trait::async_trait;
@@ -7,8 +6,8 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
-async fn build_basic_app() -> Celery<MockBroker> {
-    let celery = Celery::<MockBroker>::builder("mock-app", "mock://localhost:8000")
+async fn build_basic_app() -> Celery {
+    let celery = CeleryBuilder::new("mock-app", "mock://localhost:8000")
         .build()
         .await
         .unwrap();
@@ -17,8 +16,8 @@ async fn build_basic_app() -> Celery<MockBroker> {
     celery
 }
 
-async fn build_configured_app() -> Celery<MockBroker> {
-    let celery = Celery::<MockBroker>::builder("mock-app", "mock://localhost:8000")
+async fn build_configured_app() -> Celery {
+    let celery = CeleryBuilder::new("mock-app", "mock://localhost:8000")
         .task_time_limit(10)
         .task_max_retries(100)
         .task_content_type(MessageContentType::Yaml)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,4 +1,5 @@
 use super::{Celery, CeleryBuilder};
+use crate::broker::mock::MockBroker;
 use crate::protocol::MessageContentType;
 use crate::task::{Request, Signature, Task, TaskOptions, TaskResult};
 use async_trait::async_trait;
@@ -142,7 +143,12 @@ async fn test_add_task_registered() {
 async fn test_send_task() {
     let app = build_basic_app().await;
     let result = app.send_task(AddTask::new(1, 2)).await.unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.task == "add");
 }
@@ -154,7 +160,12 @@ async fn test_send_task_with_countdown() {
         .send_task(AddTask::new(1, 2).with_countdown(2))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.eta.is_some());
 }
@@ -166,7 +177,12 @@ async fn test_send_task_with_eta() {
         .send_task(AddTask::new(1, 2).with_eta(DateTime::<Utc>::from(SystemTime::now())))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.eta.is_some());
 }
@@ -178,7 +194,12 @@ async fn test_send_task_with_expires_in() {
         .send_task(AddTask::new(1, 2).with_expires_in(10))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.expires.is_some());
 }
@@ -191,7 +212,12 @@ async fn test_send_task_with_expires() {
         .send_task(AddTask::new(1, 2).with_expires(dt))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.expires.is_some());
 }
@@ -203,7 +229,12 @@ async fn test_send_task_with_content_type() {
         .send_task(AddTask::new(1, 2).with_content_type(MessageContentType::Yaml))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.properties.content_type == "application/x-yaml");
 }
@@ -215,7 +246,12 @@ async fn test_send_task_with_time_limit() {
         .send_task(AddTask::new(1, 2).with_time_limit(5))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (None, Some(5)));
 }
@@ -227,7 +263,12 @@ async fn test_send_task_with_hard_time_limit() {
         .send_task(AddTask::new(1, 2).with_hard_time_limit(5))
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(5), None));
 }
@@ -236,7 +277,12 @@ async fn test_send_task_with_hard_time_limit() {
 async fn test_configured_app_send_task_app_defaults() {
     let app = build_configured_app().await;
     let result = app.send_task(AddTask::new(1, 2)).await.unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (None, Some(10)));
     assert!(message.properties.content_type == "application/x-yaml");
@@ -246,7 +292,12 @@ async fn test_configured_app_send_task_app_defaults() {
 async fn test_configured_app_send_task_task_defaults() {
     let app = build_configured_app().await;
     let result = app.send_task(MultiplyTask::new(1, 2)).await.unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(10), Some(5)));
     assert!(message.properties.content_type == "application/x-yaml");
@@ -263,7 +314,12 @@ async fn test_configured_app_send_task_request_overrides() {
         )
         .await
         .unwrap();
-    let sent_tasks = app.broker.sent_tasks.read().await;
+    let mock_broker = app
+        .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap();
+    let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(10), Some(2)));
     assert!(message.properties.content_type == "application/json");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -143,11 +143,7 @@ async fn test_add_task_registered() {
 async fn test_send_task() {
     let app = build_basic_app().await;
     let result = app.send_task(AddTask::new(1, 2)).await.unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.task == "add");
@@ -160,11 +156,7 @@ async fn test_send_task_with_countdown() {
         .send_task(AddTask::new(1, 2).with_countdown(2))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.eta.is_some());
@@ -177,11 +169,7 @@ async fn test_send_task_with_eta() {
         .send_task(AddTask::new(1, 2).with_eta(DateTime::<Utc>::from(SystemTime::now())))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.eta.is_some());
@@ -194,11 +182,7 @@ async fn test_send_task_with_expires_in() {
         .send_task(AddTask::new(1, 2).with_expires_in(10))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.expires.is_some());
@@ -212,11 +196,7 @@ async fn test_send_task_with_expires() {
         .send_task(AddTask::new(1, 2).with_expires(dt))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.expires.is_some());
@@ -229,11 +209,7 @@ async fn test_send_task_with_content_type() {
         .send_task(AddTask::new(1, 2).with_content_type(MessageContentType::Yaml))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.properties.content_type == "application/x-yaml");
@@ -246,11 +222,7 @@ async fn test_send_task_with_time_limit() {
         .send_task(AddTask::new(1, 2).with_time_limit(5))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (None, Some(5)));
@@ -263,11 +235,7 @@ async fn test_send_task_with_hard_time_limit() {
         .send_task(AddTask::new(1, 2).with_hard_time_limit(5))
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(5), None));
@@ -277,11 +245,7 @@ async fn test_send_task_with_hard_time_limit() {
 async fn test_configured_app_send_task_app_defaults() {
     let app = build_configured_app().await;
     let result = app.send_task(AddTask::new(1, 2)).await.unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (None, Some(10)));
@@ -292,11 +256,7 @@ async fn test_configured_app_send_task_app_defaults() {
 async fn test_configured_app_send_task_task_defaults() {
     let app = build_configured_app().await;
     let result = app.send_task(MultiplyTask::new(1, 2)).await.unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(10), Some(5)));
@@ -314,11 +274,7 @@ async fn test_configured_app_send_task_request_overrides() {
         )
         .await
         .unwrap();
-    let mock_broker = app
-        .broker
-        .into_any()
-        .downcast::<MockBroker>()
-        .unwrap();
+    let mock_broker = app.broker.into_any().downcast::<MockBroker>().unwrap();
     let sent_tasks = mock_broker.sent_tasks.read().await;
     let message = &sent_tasks.get(&result.task_id).unwrap().0;
     assert!(message.headers.timelimit == (Some(10), Some(2)));

--- a/src/beat/mod.rs
+++ b/src/beat/mod.rs
@@ -21,7 +21,9 @@
 //! Here instead we have only one scheduler struct, and the different backends
 //! correspond to the different scheduler implementations in Python.
 
-use crate::broker::{build_and_connect, configure_task_routes, BrokerBuilder, broker_builder_from_url};
+use crate::broker::{
+    broker_builder_from_url, build_and_connect, configure_task_routes, BrokerBuilder,
+};
 use crate::routing::{self, Rule};
 use crate::{
     error::{BeatError, BrokerError},
@@ -44,8 +46,7 @@ pub use schedule::{CronSchedule, DeltaSchedule, Schedule};
 mod scheduled_task;
 pub use scheduled_task::ScheduledTask;
 
-struct Config
-{
+struct Config {
     name: String,
     broker_builder: Box<dyn BrokerBuilder>,
     broker_connection_timeout: u32,
@@ -67,8 +68,7 @@ where
     scheduler_backend: Sb,
 }
 
-impl BeatBuilder<LocalSchedulerBackend>
-{
+impl BeatBuilder<LocalSchedulerBackend> {
     /// Get a `BeatBuilder` for creating a `Beat` app with a default scheduler backend
     /// and a custom configuration.
     pub fn with_default_scheduler_backend(name: &str, broker_url: &str) -> Self {
@@ -238,36 +238,22 @@ pub struct Beat<Sb: SchedulerBackend> {
     max_sleep_duration: Option<Duration>,
 }
 
-impl Beat<LocalSchedulerBackend>
-{
+impl Beat<LocalSchedulerBackend> {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom configuration and a
     /// default scheduler backend.
-    pub fn default_builder(
-        name: &str,
-        broker_url: &str,
-    ) -> BeatBuilder<LocalSchedulerBackend> {
-        BeatBuilder::<LocalSchedulerBackend>::with_default_scheduler_backend(
-            name, broker_url,
-        )
+    pub fn default_builder(name: &str, broker_url: &str) -> BeatBuilder<LocalSchedulerBackend> {
+        BeatBuilder::<LocalSchedulerBackend>::with_default_scheduler_backend(name, broker_url)
     }
 }
 
-impl< Sb> Beat< Sb>
+impl<Sb> Beat<Sb>
 where
     Sb: SchedulerBackend,
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom configuration and
     /// a custom scheduler backend.
-    pub fn custom_builder(
-        name: &str,
-        broker_url: &str,
-        scheduler_backend: Sb,
-    ) -> BeatBuilder<Sb> {
-        BeatBuilder::<Sb>::with_custom_scheduler_backend(
-            name,
-            broker_url,
-            scheduler_backend,
-        )
+    pub fn custom_builder(name: &str, broker_url: &str, scheduler_backend: Sb) -> BeatBuilder<Sb> {
+        BeatBuilder::<Sb>::with_custom_scheduler_backend(name, broker_url, scheduler_backend)
     }
 
     /// Schedule the execution of a task.

--- a/src/beat/mod.rs
+++ b/src/beat/mod.rs
@@ -21,7 +21,7 @@
 //! Here instead we have only one scheduler struct, and the different backends
 //! correspond to the different scheduler implementations in Python.
 
-use crate::broker::{build_and_connect, configure_task_routes, Broker, BrokerBuilder};
+use crate::broker::{build_and_connect, configure_task_routes, BrokerBuilder, broker_builder_from_url};
 use crate::routing::{self, Rule};
 use crate::{
     error::{BeatError, BrokerError},
@@ -44,12 +44,10 @@ pub use schedule::{CronSchedule, DeltaSchedule, Schedule};
 mod scheduled_task;
 pub use scheduled_task::ScheduledTask;
 
-struct Config<Bb>
-where
-    Bb: BrokerBuilder,
+struct Config
 {
     name: String,
-    broker_builder: Bb,
+    broker_builder: Box<dyn BrokerBuilder>,
     broker_connection_timeout: u32,
     broker_connection_retry: bool,
     broker_connection_max_retries: u32,
@@ -61,18 +59,15 @@ where
 }
 
 /// Used to create a [`Beat`] app with a custom configuration.
-pub struct BeatBuilder<Bb, Sb>
+pub struct BeatBuilder<Sb>
 where
-    Bb: BrokerBuilder,
     Sb: SchedulerBackend,
 {
-    config: Config<Bb>,
+    config: Config,
     scheduler_backend: Sb,
 }
 
-impl<Bb> BeatBuilder<Bb, LocalSchedulerBackend>
-where
-    Bb: BrokerBuilder,
+impl BeatBuilder<LocalSchedulerBackend>
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a default scheduler backend
     /// and a custom configuration.
@@ -80,7 +75,7 @@ where
         Self {
             config: Config {
                 name: name.into(),
-                broker_builder: Bb::new(broker_url),
+                broker_builder: broker_builder_from_url(broker_url),
                 broker_connection_timeout: 2,
                 broker_connection_retry: true,
                 broker_connection_max_retries: 5,
@@ -95,9 +90,8 @@ where
     }
 }
 
-impl<Bb, Sb> BeatBuilder<Bb, Sb>
+impl<Sb> BeatBuilder<Sb>
 where
-    Bb: BrokerBuilder,
     Sb: SchedulerBackend,
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom scheduler backend and
@@ -110,7 +104,7 @@ where
         Self {
             config: Config {
                 name: name.into(),
-                broker_builder: Bb::new(broker_url),
+                broker_builder: broker_builder_from_url(broker_url),
                 broker_connection_timeout: 2,
                 broker_connection_retry: true,
                 broker_connection_max_retries: 5,
@@ -182,7 +176,7 @@ where
     }
 
     /// Construct a `Beat` app with the current configuration.
-    pub async fn build(self) -> Result<Beat<Bb::Broker, Sb>, BeatError> {
+    pub async fn build(self) -> Result<Beat<Sb>, BeatError> {
         // Declare default queue to broker.
         let broker_builder = self
             .config
@@ -227,9 +221,9 @@ where
 ///
 /// It drives execution by making the internal scheduler "tick", and updates the list of scheduled
 /// tasks through a customizable scheduler backend.
-pub struct Beat<Br: Broker, Sb: SchedulerBackend> {
+pub struct Beat<Sb: SchedulerBackend> {
     pub name: String,
-    pub scheduler: Scheduler<Br>,
+    pub scheduler: Scheduler,
     pub scheduler_backend: Sb,
 
     task_routes: Vec<Rule>,
@@ -244,25 +238,22 @@ pub struct Beat<Br: Broker, Sb: SchedulerBackend> {
     max_sleep_duration: Option<Duration>,
 }
 
-impl<Br> Beat<Br, LocalSchedulerBackend>
-where
-    Br: Broker,
+impl Beat<LocalSchedulerBackend>
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom configuration and a
     /// default scheduler backend.
     pub fn default_builder(
         name: &str,
         broker_url: &str,
-    ) -> BeatBuilder<Br::Builder, LocalSchedulerBackend> {
-        BeatBuilder::<Br::Builder, LocalSchedulerBackend>::with_default_scheduler_backend(
+    ) -> BeatBuilder<LocalSchedulerBackend> {
+        BeatBuilder::<LocalSchedulerBackend>::with_default_scheduler_backend(
             name, broker_url,
         )
     }
 }
 
-impl<Br, Sb> Beat<Br, Sb>
+impl< Sb> Beat< Sb>
 where
-    Br: Broker,
     Sb: SchedulerBackend,
 {
     /// Get a `BeatBuilder` for creating a `Beat` app with a custom configuration and
@@ -271,8 +262,8 @@ where
         name: &str,
         broker_url: &str,
         scheduler_backend: Sb,
-    ) -> BeatBuilder<Br::Builder, Sb> {
-        BeatBuilder::<Br::Builder, Sb>::with_custom_scheduler_backend(
+    ) -> BeatBuilder<Sb> {
+        BeatBuilder::<Sb>::with_custom_scheduler_backend(
             name,
             broker_url,
             scheduler_backend,

--- a/src/beat/scheduler.rs
+++ b/src/beat/scheduler.rs
@@ -14,18 +14,16 @@ const DEFAULT_SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 ///
 /// Internally it uses a min-heap to store tasks and efficiently retrieve the ones
 /// that are due for execution.
-pub struct Scheduler<B: Broker> {
+pub struct Scheduler {
     heap: BinaryHeap<ScheduledTask>,
     default_sleep_interval: Duration,
-    pub broker: B,
+    pub broker: Box<dyn Broker>,
 }
 
-impl<B> Scheduler<B>
-where
-    B: Broker,
+impl Scheduler
 {
     /// Create a new scheduler which uses the given `broker`.
-    pub fn new(broker: B) -> Scheduler<B> {
+    pub fn new(broker: Box<dyn Broker>) -> Scheduler {
         Scheduler {
             heap: BinaryHeap::new(),
             default_sleep_interval: DEFAULT_SLEEP_INTERVAL,

--- a/src/beat/scheduler.rs
+++ b/src/beat/scheduler.rs
@@ -20,8 +20,7 @@ pub struct Scheduler {
     pub broker: Box<dyn Broker>,
 }
 
-impl Scheduler
-{
+impl Scheduler {
     /// Create a new scheduler which uses the given `broker`.
     pub fn new(broker: Box<dyn Broker>) -> Scheduler {
         Scheduler {

--- a/src/beat/tests.rs
+++ b/src/beat/tests.rs
@@ -52,6 +52,9 @@ async fn test_task_with_delta_schedule() {
     let mut tasks: Vec<_> = beat
         .scheduler
         .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap()
         .sent_tasks
         .write()
         .await
@@ -119,6 +122,9 @@ async fn test_scheduling_two_tasks() {
     let (task1, task2): (Vec<_>, Vec<_>) = beat
         .scheduler
         .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap()
         .sent_tasks
         .write()
         .await
@@ -184,6 +190,9 @@ async fn test_task_with_delayed_first_run() {
     let task_count = beat
         .scheduler
         .broker
+        .into_any()
+        .downcast::<MockBroker>()
+        .unwrap()
         .sent_tasks
         .write()
         .await

--- a/src/beat/tests.rs
+++ b/src/beat/tests.rs
@@ -20,12 +20,12 @@ use tokio::time::{self, Duration};
 #[tokio::test]
 async fn test_task_with_delta_schedule() {
     // Create a dummy broker for this test.
-    let dummy_broker = MockBroker::new();
+    let dummy_broker = Box::new(MockBroker::new());
 
     // Configure a dummy queue for the tasks.
     let task_routes = vec![Rule::new("dummy_*", "dummy_queue").unwrap()];
 
-    let mut beat: Beat<MockBroker, LocalSchedulerBackend> = Beat {
+    let mut beat: Beat<LocalSchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
         scheduler_backend: LocalSchedulerBackend::new(),
@@ -81,14 +81,14 @@ async fn test_task_with_delta_schedule() {
 #[tokio::test]
 async fn test_scheduling_two_tasks() {
     // Create a dummy broker for this test.
-    let dummy_broker = MockBroker::new();
+    let dummy_broker = Box::new(MockBroker::new());
 
     // Configure dummy queues for the tasks.
     let task_routes = vec![
         Rule::new("dummy_task2", "dummy_queue2").unwrap(),
         Rule::new("dummy_*", "dummy_queue").unwrap(),
     ];
-    let mut beat: Beat<MockBroker, LocalSchedulerBackend> = Beat {
+    let mut beat: Beat<LocalSchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
         scheduler_backend: LocalSchedulerBackend::new(),
@@ -158,9 +158,9 @@ impl Schedule for TenMillisSchedule {
 #[tokio::test]
 async fn test_task_with_delayed_first_run() {
     // Create a dummy beat for this test.
-    let dummy_broker = MockBroker::new();
+    let dummy_broker = Box::new(MockBroker::new());
     let task_routes = vec![Rule::new("*", "dummy_queue").unwrap()];
-    let mut beat: Beat<MockBroker, LocalSchedulerBackend> = Beat {
+    let mut beat: Beat<LocalSchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
         scheduler_backend: LocalSchedulerBackend::new(),
@@ -232,8 +232,8 @@ async fn test_beat_max_sleep_duration() {
     }
 
     // Create a dummy beat for this test.
-    let dummy_broker = MockBroker::new();
-    let mut beat: Beat<MockBroker, DummySchedulerBackend> = Beat {
+    let dummy_broker = Box::new(MockBroker::new());
+    let mut beat: Beat<DummySchedulerBackend> = Beat {
         name: "dummy_beat".to_string(),
         scheduler: Scheduler::new(dummy_broker),
         scheduler_backend: DummySchedulerBackend {

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -23,6 +23,9 @@ use crate::protocol::{Message, MessageHeaders, MessageProperties, TryDeserialize
 use tokio_executor_trait::Tokio as TokioExecutor;
 use tokio_reactor_trait::Tokio as TokioReactor;
 
+#[cfg(test)]
+use std::any::Any;
+
 struct Consumer {
     wrapped: lapin::Consumer,
 }
@@ -375,6 +378,9 @@ impl Broker for AMQPBroker {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
 }
 
 impl Message {

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -48,8 +48,8 @@ impl super::Delivery for Delivery {
     async fn remove(&self) -> Result<(), BrokerError> {
         todo!()
     }
-    async fn _ack(&self) -> Result<(), BrokerError> {
-        self.ack(BasicAckOptions::default()).await?;
+    async fn ack(&self) -> Result<(), BrokerError> {
+        lapin::acker::Acker::ack(self, BasicAckOptions::default()).await?;
         Ok(())
     }
 }
@@ -269,7 +269,7 @@ impl Broker for AMQPBroker {
     }
 
     async fn ack(&self, delivery: &dyn super::Delivery) -> Result<(), BrokerError> {
-        delivery._ack().await
+        delivery.ack().await
     }
 
     async fn retry(

--- a/src/broker/mock.rs
+++ b/src/broker/mock.rs
@@ -13,6 +13,9 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 use tokio::sync::RwLock;
 
+#[cfg(test)]
+use std::any::Any;
+
 pub struct MockBrokerBuilder;
 
 #[async_trait]
@@ -121,6 +124,9 @@ impl Broker for MockBroker {
     async fn reconnect(&self, connection_timeout: u32) -> Result<(), BrokerError> {
         Ok(())
     }
+
+    #[cfg(test)]
+    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
 }
 
 #[derive(Debug, Clone)]

--- a/src/broker/mock.rs
+++ b/src/broker/mock.rs
@@ -126,7 +126,9 @@ impl Broker for MockBroker {
     }
 
     #[cfg(test)]
-    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -26,7 +26,11 @@ use std::any::Any;
 /// The type representing a successful delivery.
 #[async_trait]
 pub trait Delivery: TryDeserializeMessage + Send + Sync + std::fmt::Debug {
-    async fn resend(&self, broker: &dyn Broker, eta: Option<DateTime<Utc>>) -> Result<(), BrokerError>;
+    async fn resend(
+        &self,
+        broker: &dyn Broker,
+        eta: Option<DateTime<Utc>>,
+    ) -> Result<(), BrokerError>;
     async fn remove(&self) -> Result<(), BrokerError>;
     async fn _ack(&self) -> Result<(), BrokerError>;
 }
@@ -35,7 +39,10 @@ pub trait Delivery: TryDeserializeMessage + Send + Sync + std::fmt::Debug {
 pub trait DeliveryError: std::fmt::Display + Send + Sync {}
 
 /// The stream type that the [`Celery`](crate::Celery) app will consume deliveries from.
-pub trait DeliveryStream: Stream<Item = Result<Box<dyn Delivery>, Box<dyn DeliveryError>>> + Unpin {}
+pub trait DeliveryStream:
+    Stream<Item = Result<Box<dyn Delivery>, Box<dyn DeliveryError>>> + Unpin
+{
+}
 
 /// A message [`Broker`] is used as the transport for producing or consuming tasks.
 #[async_trait]
@@ -96,7 +103,9 @@ pub trait Broker: Send + Sync {
 #[async_trait]
 pub trait BrokerBuilder {
     /// Create a new `BrokerBuilder`.
-    fn new(broker_url: &str) -> Self where Self: Sized;
+    fn new(broker_url: &str) -> Self
+    where
+        Self: Sized;
 
     /// Set the prefetch count.
     fn prefetch_count(self: Box<Self>, prefetch_count: u16) -> Box<dyn BrokerBuilder>;
@@ -111,7 +120,7 @@ pub trait BrokerBuilder {
     async fn build(&self, connection_timeout: u32) -> Result<Box<dyn Broker>, BrokerError>;
 }
 
-pub(crate) fn broker_builder_from_url(broker_url: &str) -> Box<dyn BrokerBuilder>{
+pub(crate) fn broker_builder_from_url(broker_url: &str) -> Box<dyn BrokerBuilder> {
     match broker_url.split_once("://") {
         Some(("amqp", _)) => Box::new(AMQPBrokerBuilder::new(broker_url)),
         Some(("redis", _)) => Box::new(RedisBrokerBuilder::new(broker_url)),

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -32,7 +32,7 @@ pub trait Delivery: TryDeserializeMessage + Send + Sync + std::fmt::Debug {
         eta: Option<DateTime<Utc>>,
     ) -> Result<(), BrokerError>;
     async fn remove(&self) -> Result<(), BrokerError>;
-    async fn _ack(&self) -> Result<(), BrokerError>;
+    async fn ack(&self) -> Result<(), BrokerError>;
 }
 
 /// The error type of an unsuccessful delivery.

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -20,6 +20,9 @@ pub use amqp::{AMQPBroker, AMQPBrokerBuilder};
 
 #[cfg(test)]
 pub mod mock;
+#[cfg(test)]
+use std::any::Any;
+
 /// The type representing a successful delivery.
 #[async_trait]
 pub trait Delivery: TryDeserializeMessage + Send + Sync + std::fmt::Debug {
@@ -84,6 +87,9 @@ pub trait Broker: Send + Sync {
 
     /// Try reconnecting in the event of some sort of connection error.
     async fn reconnect(&self, connection_timeout: u32) -> Result<(), BrokerError>;
+
+    #[cfg(test)]
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 /// A [`BrokerBuilder`] is used to create a type of broker with a custom configuration.

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -1,6 +1,6 @@
 //! Redis broker.
 #![allow(dead_code)]
-use super::{Broker, BrokerBuilder, DeliveryStream, DeliveryError};
+use super::{Broker, BrokerBuilder, DeliveryError, DeliveryStream};
 use crate::error::{BrokerError, ProtocolError};
 use crate::protocol::Delivery;
 use crate::protocol::Message;
@@ -217,17 +217,21 @@ impl DeliveryStream for Consumer {}
 
 #[async_trait]
 impl super::Delivery for (Channel, Delivery) {
-    async fn resend(&self, _broker: &dyn Broker, _eta: Option<DateTime<Utc>>) -> Result<(), BrokerError> {
+    async fn resend(
+        &self,
+        _broker: &dyn Broker,
+        _eta: Option<DateTime<Utc>>,
+    ) -> Result<(), BrokerError> {
         self.0.resend_task(&self.1).await?;
         Ok(())
     }
 
-    async fn remove(&self) -> Result<(), BrokerError>{
+    async fn remove(&self) -> Result<(), BrokerError> {
         self.0.remove_task(&self.1).await?;
         Ok(())
     }
 
-    async fn _ack(&self) -> Result<(), BrokerError>{
+    async fn _ack(&self) -> Result<(), BrokerError> {
         todo!()
     }
 }
@@ -426,5 +430,7 @@ impl Broker for RedisBroker {
     }
 
     #[cfg(test)]
-    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
 }

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -23,6 +23,9 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+#[cfg(test)]
+use std::any::Any;
+
 struct Config {
     broker_url: String,
     prefetch_count: u16,
@@ -421,4 +424,7 @@ impl Broker for RedisBroker {
             }
         }
     }
+
+    #[cfg(test)]
+    fn into_any(self: Box<Self>) -> Box<dyn Any> { self }
 }

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -231,7 +231,7 @@ impl super::Delivery for (Channel, Delivery) {
         Ok(())
     }
 
-    async fn _ack(&self) -> Result<(), BrokerError> {
+    async fn ack(&self) -> Result<(), BrokerError> {
         todo!()
     }
 }

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -1,6 +1,6 @@
 //! Redis broker.
 #![allow(dead_code)]
-use super::{Broker, BrokerBuilder};
+use super::{Broker, BrokerBuilder, DeliveryStream, DeliveryError};
 use crate::error::{BrokerError, ProtocolError};
 use crate::protocol::Delivery;
 use crate::protocol::Message;
@@ -36,8 +36,6 @@ pub struct RedisBrokerBuilder {
 
 #[async_trait]
 impl BrokerBuilder for RedisBrokerBuilder {
-    type Broker = RedisBroker;
-
     /// Create a new `BrokerBuilder`.
     fn new(broker_url: &str) -> Self {
         RedisBrokerBuilder {
@@ -51,26 +49,26 @@ impl BrokerBuilder for RedisBrokerBuilder {
     }
 
     /// Set the prefetch count.
-    fn prefetch_count(mut self, prefetch_count: u16) -> Self {
+    fn prefetch_count(mut self: Box<Self>, prefetch_count: u16) -> Box<dyn BrokerBuilder> {
         self.config.prefetch_count = prefetch_count;
         self
     }
 
     /// Declare a queue.
-    fn declare_queue(mut self, name: &str) -> Self {
+    fn declare_queue(mut self: Box<Self>, name: &str) -> Box<dyn BrokerBuilder> {
         self.config.queues.insert(name.into());
         self
     }
 
     /// Set the heartbeat.
-    fn heartbeat(mut self, heartbeat: Option<u16>) -> Self {
+    fn heartbeat(mut self: Box<Self>, heartbeat: Option<u16>) -> Box<dyn BrokerBuilder> {
         warn!("Setting heartbeat on redis broker has no effect on anything");
         self.config.heartbeat = heartbeat;
         self
     }
 
     /// Construct the `Broker` with the given configuration.
-    async fn build(&self, _connection_timeout: u32) -> Result<Self::Broker, BrokerError> {
+    async fn build(&self, _connection_timeout: u32) -> Result<Box<dyn Broker>, BrokerError> {
         let mut queues: HashSet<String> = HashSet::new();
         for queue_name in &self.config.queues {
             queues.insert(queue_name.into());
@@ -87,7 +85,7 @@ impl BrokerBuilder for RedisBrokerBuilder {
         println!("Creating mpsc channel");
         let (tx, rx) = channel(1);
         println!("Creating broker");
-        Ok(RedisBroker {
+        Ok(Box::new(RedisBroker {
             uri: self.config.broker_url.clone(),
             queues,
             client,
@@ -96,7 +94,7 @@ impl BrokerBuilder for RedisBrokerBuilder {
             pending_tasks: Arc::new(AtomicU16::new(0)),
             waker_rx: Mutex::new(rx),
             waker_tx: tx,
-        })
+        }))
     }
 }
 
@@ -212,6 +210,25 @@ pub struct Consumer {
     prefetch_count: Arc<AtomicU16>,
 }
 
+impl DeliveryStream for Consumer {}
+
+#[async_trait]
+impl super::Delivery for (Channel, Delivery) {
+    async fn resend(&self, _broker: &dyn Broker, _eta: Option<DateTime<Utc>>) -> Result<(), BrokerError> {
+        self.0.resend_task(&self.1).await?;
+        Ok(())
+    }
+
+    async fn remove(&self) -> Result<(), BrokerError>{
+        self.0.remove_task(&self.1).await?;
+        Ok(())
+    }
+
+    async fn _ack(&self) -> Result<(), BrokerError>{
+        todo!()
+    }
+}
+
 impl TryDeserializeMessage for (Channel, Delivery) {
     fn try_deserialize_message(&self) -> Result<Message, ProtocolError> {
         self.1.try_deserialize_message()
@@ -219,7 +236,7 @@ impl TryDeserializeMessage for (Channel, Delivery) {
 }
 
 impl Stream for Consumer {
-    type Item = Result<(Channel, Delivery), BrokerError>;
+    type Item = Result<Box<dyn super::Delivery>, Box<dyn DeliveryError>>;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -243,7 +260,7 @@ impl Stream for Consumer {
             match item {
                 Ok(item) => {
                     self.pending_tasks.fetch_add(1, Ordering::SeqCst);
-                    Poll::Ready(Some(Ok((self.channel.clone(), item))))
+                    Poll::Ready(Some(Ok(Box::new((self.channel.clone(), item)))))
                 }
                 Err(err) => {
                     (self.error_handler)(err);
@@ -260,17 +277,6 @@ impl Stream for Consumer {
 
 #[async_trait]
 impl Broker for RedisBroker {
-    /// The builder type used to create the broker with a custom configuration.
-    type Builder = RedisBrokerBuilder;
-    type Delivery = (Channel, Delivery);
-    type DeliveryError = BrokerError;
-    type DeliveryStream = Consumer;
-
-    /// Returns a builder for creating a broker with a custom configuration.
-    fn builder(broker_url: &str) -> Self::Builder {
-        Self::Builder::new(broker_url)
-    }
-
     /// Consume messages from a queue.
     ///
     /// If the connection is successful, this should return a future stream of `Result`s where an `Ok`
@@ -278,11 +284,11 @@ impl Broker for RedisBroker {
     /// type that can be coerced into a [`Message`](protocol/struct.Message.html)
     /// and an `Err` value is a
     /// [`Self::DeliveryError`](trait.Broker.html#associatedtype.DeliveryError) type.
-    async fn consume<E: Fn(BrokerError) + Send + Sync + 'static>(
+    async fn consume(
         &self,
         queue: &str,
-        error_handler: Box<E>,
-    ) -> Result<(String, Self::DeliveryStream), BrokerError> {
+        error_handler: Box<dyn Fn(BrokerError) + Send + Sync + 'static>,
+    ) -> Result<(String, Box<dyn DeliveryStream>), BrokerError> {
         let consumer = Consumer {
             channel: Channel {
                 connection: self.manager.clone(),
@@ -300,7 +306,7 @@ impl Broker for RedisBroker {
         let uuid = Uuid::new_v4().to_hyphenated().encode_lower(&mut buffer);
         let consumer_tag = uuid.to_owned();
 
-        Ok((consumer_tag, consumer))
+        Ok((consumer_tag, Box::new(consumer)))
     }
 
     async fn cancel(&self, _consumer_tag: &str) -> Result<(), BrokerError> {
@@ -308,10 +314,9 @@ impl Broker for RedisBroker {
     }
 
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.
-    async fn ack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError> {
+    async fn ack(&self, delivery: &dyn super::Delivery) -> Result<(), BrokerError> {
         self.pending_tasks.fetch_sub(1, Ordering::SeqCst);
-        let (channel, delivery) = delivery;
-        channel.remove_task(delivery).await?;
+        delivery.remove().await?;
         let mut waker_rx = self.waker_rx.lock().await;
         // work around for try_recv. We do not care if a waker is available after this check.
         let dummy_waker = futures::task::noop_waker_ref();
@@ -325,11 +330,10 @@ impl Broker for RedisBroker {
     /// Retry a delivery.
     async fn retry(
         &self,
-        delivery: &Self::Delivery,
-        _eta: Option<DateTime<Utc>>,
+        delivery: &dyn super::Delivery,
+        eta: Option<DateTime<Utc>>,
     ) -> Result<(), BrokerError> {
-        let (channel, delivery_msg) = delivery;
-        channel.resend_task(delivery_msg).await?;
+        delivery.resend(self, eta).await?;
         // self.ack(delivery).await?;
         Ok(())
     }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -9,9 +9,9 @@ macro_rules! __app_internal {
         [ $( $pattern:expr => $queue:expr ),* ],
         $( $x:ident = $y:expr, )*
     ) => {{
-        async fn _build_app(mut builder: $crate::CeleryBuilder::<<$broker_type as $crate::broker::Broker>::Builder>) ->
-            $crate::export::Result<$crate::export::Arc<$crate::Celery::<$broker_type>>> {
-            let celery: $crate::Celery<$broker_type> = builder.build().await?;
+        async fn _build_app(mut builder: $crate::CeleryBuilder) ->
+            $crate::export::Result<$crate::export::Arc<$crate::Celery>> {
+            let celery: $crate::Celery = builder.build().await?;
 
             $(
                 celery.register_task::<$t>().await?;
@@ -22,7 +22,7 @@ macro_rules! __app_internal {
 
         let broker_url = $broker_url;
 
-        let mut builder = $crate::Celery::<$broker_type>::builder("celery", &broker_url);
+        let mut builder = $crate::CeleryBuilder::new("celery", &broker_url);
 
         $(
             builder = builder.$x($y);
@@ -52,8 +52,8 @@ macro_rules! __beat_internal {
         [ $( $pattern:expr => $queue:expr ),* ],
         $( $x:ident = $y:expr, )*
     ) => {{
-        async fn _build_beat(mut builder: $crate::beat::BeatBuilder::<<$broker_type as $crate::broker::Broker>::Builder, $scheduler_backend_type>) ->
-            $crate::export::BeatResult<$crate::beat::Beat::<$broker_type, $scheduler_backend_type>> {
+        async fn _build_beat(mut builder: $crate::beat::BeatBuilder::<$scheduler_backend_type>) ->
+            $crate::export::BeatResult<$crate::beat::Beat::<$scheduler_backend_type>> {
             let mut beat = builder.build().await?;
 
             $(
@@ -65,7 +65,7 @@ macro_rules! __beat_internal {
 
         let broker_url = $broker_url;
 
-        let mut builder = $crate::beat::Beat::<$broker_type, $scheduler_backend_type>::custom_builder("beat", &broker_url, $scheduler_backend);
+        let mut builder = $crate::beat::Beat::<$scheduler_backend_type>::custom_builder("beat", &broker_url, $scheduler_backend);
 
         $(
             builder = builder.$x($y);

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -674,8 +674,8 @@ pub struct Delivery {
     pub properties: DeliveryProperties,
 }
 
-impl Delivery {
-    pub fn try_deserialize_message(&self) -> Result<Message, ProtocolError> {
+impl TryDeserializeMessage for Delivery {
+    fn try_deserialize_message(&self) -> Result<Message, ProtocolError> {
         let raw_body = match self.properties.body_encoding {
             BodyEncoding::Base64 => base64::decode(self.body.clone())
                 .map_err(|e| ProtocolError::InvalidProperty(format!("body error: {e}")))?,

--- a/tests/app_codegen/mod.rs
+++ b/tests/app_codegen/mod.rs
@@ -1,7 +1,5 @@
 //! These tests should be compiled but not run.
 
-use celery::prelude::*;
-
 #[tokio::test]
 async fn test_basic_use() {
     let _app = celery::app!(

--- a/tests/beat_codegen/mod.rs
+++ b/tests/beat_codegen/mod.rs
@@ -1,5 +1,3 @@
-use celery::prelude::*;
-
 #[tokio::test]
 async fn test_basic_use() {
     let _beat = celery::beat!(

--- a/tests/brokers/amqp.rs
+++ b/tests/brokers/amqp.rs
@@ -1,7 +1,6 @@
 #![allow(non_upper_case_globals)]
 
 use async_trait::async_trait;
-use celery::broker::{AMQPBroker, Broker};
 use celery::error::TaskError;
 use celery::task::{Request, Signature, Task, TaskOptions};
 use once_cell::sync::Lazy;

--- a/tests/brokers/redis.rs
+++ b/tests/brokers/redis.rs
@@ -1,8 +1,6 @@
 #![allow(non_upper_case_globals)]
 use anyhow::Result;
 use async_trait::async_trait;
-use celery::broker::Broker;
-use celery::broker::RedisBroker;
 use celery::error::TaskError;
 use celery::task::{Request, Signature, Task, TaskOptions};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
Fixes #276. Based on work started by @Anakael [here](https://github.com/rusty-celery/rusty-celery/pull/277#issuecomment-996168247).

The basic approach is to `Box<dyn *>` the broker and all types used in that trait. I've had to create a few wrappers around types from crates in order to implement the needed traits, mostly for the `AMQPBroker`.

Something I'm not crazy about is the methods in the Delivery trait. It seemed the cleanest logic wise to have the deliveries know how to `ack` and `resend`, but from an architecture perspective it smells to me. I didn't want to introduce to many big changes in one PR though. I'm all ears for a better solution if one can be thought of.