### PR TITLE
build(deps): Upgrade all deps

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,5 +3,7 @@ max-line-length = 115
 
 ignore =
     # these rules don't play well with black
-    E203  # whitespace before :
-    W503  # line break before binary operator
+    # whitespace before :
+    E203
+    # line break before binary operator
+    W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Cache pip
       uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Generate release notes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Bumped base64 to it's latest and safest version
+- Bumped tokio to it's latest version
+- Bumped rmp-serde to it's latest version
+- Bumped serde_yaml to it's latest version
+- Bumped uuid to it's latest version
+- Bumped once_cell to it's latest version
+- Bumped redis to it's latest version
+- Bumped env_logger to it's latest version
+- Bumped mypy to it's latest version
+- Bumped black to it's latest version
+- Bumped flake8 to it's latest version
+
 ## [v0.5.0](https://github.com/rusty-celery/rusty-celery/releases/tag/v0.5.0) - 2023-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+
 - Bumped base64 to it's latest and safest version
 - Bumped tokio to it's latest version
 - Bumped rmp-serde to it's latest version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,39 +24,39 @@ path = "src/lib.rs"
 name = "celery_app"
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.2.1", features = ["full"]}
+tokio = { version = "1.25", features = ["full"]}
 tokio-stream = "0.1.9"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-rmp-serde = { version = "0.15", optional = true }
-rmpv = { version = "1.0.0", optional = true, features = ["with-serde"] }
-serde_yaml = { version = "0.8", optional = true }
+rmp-serde = { version = "1.1", optional = true }
+rmpv = { version = "1.0", optional = true, features = ["with-serde"] }
+serde_yaml = { version = "0.9", optional = true }
 serde-pickle = { version = "1.1", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
 lapin = { version = "2.1.1", default-features = false }
 log = "0.4"
 futures = { version = "0.3", features = ["async-await"] }
-uuid = { version = "0.8", features = ["v4"]}
+uuid = { version = "1.3", features = ["v4"]}
 rand = "0.8"
 celery-codegen = { version = "0.5.0", path = "./celery-codegen", optional = true }
 colored = "2"
-once_cell = { version = "1.3.1" }
+once_cell = { version = "1.17" }
 globset = "0.4"
-hostname = "0.3.0"
-redis = { version = "0.21.1", features=["connection-manager", "tokio-comp"] }
-tokio-executor-trait = "2.1.0"
-tokio-reactor-trait = "1.1.0"
-futures-lite = "1.12.0"
+hostname = "0.3"
+redis = { version = "0.22", features=["connection-manager", "tokio-comp"] }
+tokio-executor-trait = "2.1"
+tokio-reactor-trait = "1.1"
+futures-lite = "1.12"
 
 [dev-dependencies]
-rmp-serde = "0.15"
-rmpv = { version = "1.0.0", features = ["with-serde"] }
-serde_yaml = "0.8"
+rmp-serde = "1.1"
+rmpv = { version = "1.0", features = ["with-serde"] }
+serde_yaml = "0.9"
 serde-pickle = "1.1"
-env_logger = "0.9"
+env_logger = "0.10"
 anyhow = "1.0"
 structopt = "0.3"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 # Checks style, syntax, and other useful errors.
-flake8
+flake8==6.0.0
 
 # Static type checking
-mypy==0.910
+mypy==1.0.0
 
 # Automatic code formatting
-black==22.8.0
+black==23.1.0

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -310,7 +310,7 @@ impl Broker for RedisBroker {
 
         // Create unique consumer tag.
         let mut buffer = Uuid::encode_buffer();
-        let uuid = Uuid::new_v4().to_hyphenated().encode_lower(&mut buffer);
+        let uuid = Uuid::new_v4().hyphenated().encode_lower(&mut buffer);
         let consumer_tag = uuid.to_owned();
 
         Ok((consumer_tag, Box::new(consumer)))

--- a/src/protocol/tests.rs
+++ b/src/protocol/tests.rs
@@ -70,7 +70,8 @@ fn test_deserialize_body_with_args() {
     assert_eq!(body.1.a, 4);
 }
 
-const YAML: &str = "---\n- []\n- a: 4\n- callbacks: ~\n  errbacks: ~\n  chain: ~\n  chord: ~\n";
+const YAML: &str =
+    "- []\n- a: 4\n- callbacks: null\n  errbacks: null\n  chain: null\n  chord: null\n";
 
 #[test]
 fn test_yaml_serialize_body() {
@@ -227,7 +228,9 @@ fn test_serialization() {
     assert_eq!(ser_msg_json["headers"]["argsrepr"], "(1)");
     assert_eq!(ser_msg_json["headers"]["kwargsrepr"], "{'y': 2}");
     assert_eq!(ser_msg_json["headers"]["origin"], "gen123@piper");
-    let body = base64::decode(ser_msg_json["body"].as_str().unwrap()).unwrap();
+    let body = ENGINE
+        .decode(ser_msg_json["body"].as_str().unwrap())
+        .unwrap();
     assert_eq!(body.len(), 73);
     assert_eq!(&body, JSON.as_bytes());
 }


### PR DESCRIPTION
## build(deps): Upgrade all deps
- Fix code when required by API changes in deps

[deps]
- Update base64 to version 0.21
- Update tokio to version 1.25
- Update rmp-serde to version 1.1
- Update serde_yaml to version 0.9
- Update uuid to version 1.3
- Update once_cell to version 1.17
- Update redis to version 0.22

[dev-deps]
- Update env_logger to version 0.10