### PR TITLE
Bump chrono version for with_ymd_and_hms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "celery_app"
 
 [dependencies]
 base64 = "0.21"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.23", features = ["serde"] }
 tokio = { version = "1.25", features = ["full"]}
 tokio-stream = "0.1.9"
 serde = { version = "1.0", features = ["derive"]}


### PR DESCRIPTION
My earlier PR (https://github.com/rusty-celery/rusty-celery/pull/292) used the `with_ymd_and_hms` method from chrono, but it turns out [that was only added on 0.4.23](https://github.com/chronotope/chrono/commit/7ba090d484cb93f73e5a7803dd62e4c4295f3b50) but this repo depended only on 0.4. This PR therefore upgrades the minimum required chrono version