### PR TITLE
fix sending a message from a rust client to a python worker with redis broker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rmp-serde = { version = "1.1", optional = true }
 rmpv = { version = "1.0", optional = true, features = ["with-serde"] }
 serde_yaml = { version = "0.9", optional = true }
 serde-pickle = { version = "1.1", optional = true }
-thiserror = "1.0.2"
+thiserror = "1.0"
 async-trait = "0.1.43"
 lapin = { version = "2.1.1", default-features = false }
 log = "0.4"

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -533,6 +533,7 @@ impl TryDeserializeMessage for Delivery {
                         ProtocolError::MissingRequiredProperty("content_encoding".into())
                     })?,
                 reply_to: self.properties.reply_to().as_ref().map(|v| v.to_string()),
+                delivery_info: None,
             },
             headers: MessageHeaders {
                 id: get_header_str_required(headers, "id")?,
@@ -634,6 +635,7 @@ mod tests {
                 content_type: "application/json".into(),
                 content_encoding: "utf-8".into(),
                 reply_to: Some("bbb".into()),
+                delivery_info: None,
             },
             headers: MessageHeaders {
                 id: "aaa".into(),

--- a/src/protocol/tests.rs
+++ b/src/protocol/tests.rs
@@ -58,6 +58,7 @@ fn test_deserialize_body_with_args() {
             content_type: "application/json".into(),
             content_encoding: "utf-8".into(),
             reply_to: None,
+            delivery_info: None,
         },
         headers: MessageHeaders {
             id: "aaa".into(),
@@ -88,6 +89,7 @@ fn test_yaml_deserialize_body_with_args() {
             content_type: "application/x-yaml".into(),
             content_encoding: "utf-8".into(),
             reply_to: None,
+            delivery_info: None,
         },
         headers: MessageHeaders {
             id: "aaa".into(),
@@ -117,6 +119,7 @@ fn test_pickle_deserialize_body_with_args() {
             content_type: "application/x-python-serialize".into(),
             content_encoding: "utf-8".into(),
             reply_to: None,
+            delivery_info: None,
         },
         headers: MessageHeaders {
             id: "aaa".into(),
@@ -146,6 +149,7 @@ fn test_msgpack_deserialize_body_with_args() {
             content_type: "application/x-msgpack".into(),
             content_encoding: "utf-8".into(),
             reply_to: None,
+            delivery_info: None,
         },
         headers: MessageHeaders {
             id: "aaa".into(),
@@ -173,6 +177,7 @@ fn test_serialization() {
             content_type: "application/json".into(),
             content_encoding: "utf-8".into(),
             reply_to: Some("bbb".into()),
+            delivery_info: None,
         },
         headers: MessageHeaders {
             id: "aaa".into(),
@@ -193,7 +198,7 @@ fn test_serialization() {
         },
         raw_body: Vec::from(JSON),
     };
-    let ser_msg_result = message.json_serialized();
+    let ser_msg_result = message.json_serialized(None);
     assert!(ser_msg_result.is_ok());
     let ser_msg = ser_msg_result.unwrap();
     let ser_msg_json: serde_json::Value = serde_json::from_slice(&ser_msg[..]).unwrap();


### PR DESCRIPTION
This adds a delivery info to messages. It basically does the same as https://github.com/rusty-celery/rusty-celery/pull/253/files but allows for the broker to customize the delivery info to modify the exchange / routing key wich can be used from the amqp broker (though this PR does no surface an interface to it).

In particluar, this fixes the issue of sending a message from a rust client to a python worker. Without this fix this fails with:

Unrecoverable error: KeyError('exchange')

as kombu/transport/redis.py tries to access the exchange and routing key from the delivery info.