### PR TITLE
allow setting task option `expires` on task decorator

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -93,6 +93,7 @@ impl Task for MultiplyTask {
     const DEFAULTS: TaskOptions = TaskOptions {
         time_limit: Some(5),
         hard_time_limit: Some(10),
+        expires: None,
         max_retries: Some(1000),
         min_retry_delay: None,
         max_retry_delay: None,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -192,9 +192,9 @@ where
         self
     }
 
-    pub fn expires_in(self, expires_in: u32) -> Self {
+    pub fn expires_in(self, expires_in: Duration) -> Self {
         let now = DateTime::<Utc>::from(SystemTime::now());
-        let expires = now + Duration::seconds(expires_in as i64);
+        let expires = now + expires_in;
         self.expires(expires)
     }
 
@@ -496,18 +496,32 @@ where
             builder = builder.eta(eta);
         }
 
-        // 'expires_in' arbitrarily takes priority over 'expires'.
-        if let Some(expires_in) = task_sig.expires_in.take() {
-            builder = builder.expires_in(expires_in);
-            if task_sig.expires.is_some() {
+        // 'expires_in' arbitrarily takes priority over 'expires' which takes
+        // priority over the default 'expires' property of the task options.
+        match (
+            task_sig.expires_in.take(),
+            task_sig.expires.take(),
+            task_sig.options.expires,
+        ) {
+            (Some(expires_in), None, None) => {
+                builder = builder.expires_in(Duration::seconds(expires_in as i64));
+            }
+            (Some(_), Some(expires), None) => {
                 warn!(
                     "Task {} specified both 'expires_in' and 'expires'. Ignoring 'expires'.",
                     T::NAME
-                )
+                );
+                builder = builder.expires(expires);
             }
-        } else if let Some(expires) = task_sig.expires.take() {
-            builder = builder.expires(expires);
-        }
+            (None, Some(expires), None) => {
+                builder = builder.expires(expires);
+            }
+            (None, None, Some(expires)) => {
+                builder =
+                    builder.expires_in(Duration::from_std(expires).unwrap_or(Duration::zero()))
+            }
+            _ => {}
+        };
 
         #[cfg(any(test, feature = "extra_content_types"))]
         if let Some(content_type) = task_sig.options.content_type {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -52,6 +52,7 @@ pub trait Task: Send + Sync + std::marker::Sized {
     const DEFAULTS: TaskOptions = TaskOptions {
         time_limit: None,
         hard_time_limit: None,
+        expires: None,
         max_retries: None,
         min_retry_delay: None,
         max_retry_delay: None,

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -49,6 +49,12 @@ pub struct TaskOptions {
     /// - [`with_hard_time_limit`](crate::task::Signature::method.with_hard_time_limit) at the request / signature level.
     pub hard_time_limit: Option<u32>,
 
+    /// Time in seconds in the future for the task should expire. The task won’t be
+    /// executed after the expiration time. This can be overridden when calling the task, see
+    /// [`Signature::with_expires`](crate::task::Signature::with_expires) and
+    /// [`Signature::with_expires_in`](crate::task::Signature::with_expires_in).
+    pub expires: Option<std::time::Duration>,
+
     /// Maximum number of retries for this task.
     ///
     /// This can be set with

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -49,7 +49,7 @@ pub struct TaskOptions {
     /// - [`with_hard_time_limit`](crate::task::Signature::method.with_hard_time_limit) at the request / signature level.
     pub hard_time_limit: Option<u32>,
 
-    /// Time in seconds in the future for the task should expire. The task won’t be
+    /// Time in seconds for when the task should expire. The task won’t be
     /// executed after the expiration time. This can be overridden when calling the task, see
     /// [`Signature::with_expires`](crate::task::Signature::with_expires) and
     /// [`Signature::with_expires_in`](crate::task::Signature::with_expires_in).

--- a/tests/task_codegen/mod.rs
+++ b/tests/task_codegen/mod.rs
@@ -64,6 +64,16 @@ fn bound_task_with_other_params(t: &Self, default_time_limit: u32) -> TaskResult
     Ok(t.time_limit().unwrap_or(default_time_limit))
 }
 
+#[celery::task(expires = 2)]
+fn bound_task_with_expires_as_seconds() -> TaskResult<()> {
+    Ok(())
+}
+
+#[celery::task(expires = std::time::Duration::from_millis(150))]
+fn bound_task_with_expires_as_duration() -> TaskResult<()> {
+    Ok(())
+}
+
 // This didn't work before since Task::run took a reference to self
 // instead of consuming self, so it was like
 //


### PR DESCRIPTION
This adds the `expires` option as a task attribute so that an upper time bound can be set by default on tasks.