### PR TITLE
fix: use anon-const for wrapping expanded impls

### DIFF
--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -679,11 +679,6 @@ impl ToTokens for Task {
             None => quote! {},
         };
 
-        let dummy_const = syn::Ident::new(
-            &format!("__IMPL_CELERY_TASK_FOR_{wrapper}"),
-            Span::call_site(),
-        );
-
         let output = quote! {
             #wrapper_struct
 
@@ -695,7 +690,7 @@ impl ToTokens for Task {
                 #serialized_fields
             }
 
-            const #dummy_const: () = {
+            const _: () = {
                 use #export::async_trait;
 
                 #[async_trait]


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/issues/120363, nightly builds fail on:
```
error: non-local `impl` definition, they should be avoided as they go against expectation
  --> common/src/task.rs:6:9
   |
6  |           #[celery::task(bind = true)]
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: move this `impl` block outside the of the current constant `__IMPL_CELERY_TASK_FOR_do_refresh_ssh_keys`
   = note: an `impl` definition is non-local if it is nested inside an item and neither the type nor the trait are at the same nesting level as the `impl` block
   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
   = note: the attribute macro `celery::task` may come from an old version of the `celery_codegen` crate, try updating your dependency with `cargo update -p celery_codegen`
   = note: this error originates in the attribute macro `celery::task` which comes from the expansion of the macro `shared_task` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Fixed similarly as in https://github.com/dtolnay/typetag/commit/d51f4adc253f12a02939625ebbab9305ca66f567