### PR TITLE
Add `acks_on_failure` and `nacks_enabled` options

### DIFF
--- a/celery-codegen/src/task.rs
+++ b/celery-codegen/src/task.rs
@@ -183,7 +183,6 @@ impl TaskAttrs {
             .next()
     }
 
-
     fn content_type(&self) -> Option<syn::Ident> {
         self.attrs
             .iter()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -516,7 +516,7 @@ where
 
         // If acks_late is false, we acknowledge the message before tracing it.
         if !tracer.acks_late() {
-            self.notify_message_processed_succesfuly(&delivery).await?;
+            self.notify_message_processed_successfully(&delivery).await?;
             self.broker.on_message_processed(&delivery).await?;
         }
 
@@ -539,7 +539,7 @@ where
         // If we have not done it before, we have to acknowledge the message now.
         if tracer.acks_late() {
             if tracer_result.is_ok() {
-                self.notify_message_processed_succesfuly(&delivery).await?;
+                self.notify_message_processed_successfully(&delivery).await?;
             } else {
                 self.notify_message_process_failed(
                     &delivery,
@@ -576,7 +576,7 @@ where
     }
 
     /// Notify the broker that we correctly processed the message.
-    async fn notify_message_processed_succesfuly(
+    async fn notify_message_processed_successfully(
         &self,
         delivery: &B::Delivery,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -98,6 +98,8 @@ impl Task for MultiplyTask {
         max_retry_delay: None,
         retry_for_unexpected: None,
         acks_late: None,
+        acks_on_failure_or_timeout: None,
+        nacks_enabled: None,
         content_type: None,
     };
 

--- a/src/app/trace.rs
+++ b/src/app/trace.rs
@@ -201,6 +201,14 @@ where
     fn acks_late(&self) -> bool {
         self.task.acks_late()
     }
+
+    fn acks_on_failure_or_timeout(&self) -> bool {
+        self.task.acks_on_failure_or_timeout()
+    }
+
+    fn nacks_enabled(&self) -> bool {
+        self.task.nacks_enabled()
+    }
 }
 
 #[async_trait]
@@ -217,6 +225,10 @@ pub(super) trait TracerTrait: Send + Sync {
     fn is_expired(&self) -> bool;
 
     fn acks_late(&self) -> bool;
+
+    fn acks_on_failure_or_timeout(&self) -> bool;
+
+    fn nacks_enabled(&self) -> bool;
 }
 
 pub(super) type TraceBuilderResult = Result<Box<dyn TracerTrait>, ProtocolError>;

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -221,8 +221,7 @@ impl Broker for AMQPBroker {
     async fn nack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError> {
         delivery
             .1
-            //.reject(BasicRejectOptions::default())
-            .reject(BasicRejectOptions { requeue: true })
+            .reject(BasicRejectOptions::default())
             .await
             .map_err(|e| e.into())
     }
@@ -232,7 +231,12 @@ impl Broker for AMQPBroker {
         delivery: &Self::Delivery,
         eta: Option<DateTime<Utc>>,
     ) -> Result<(), BrokerError> {
-        let mut headers = delivery.1.properties.headers().clone().unwrap_or_default();
+        let mut headers = delivery
+            .1
+            .properties
+            .headers()
+            .clone()
+            .unwrap_or_else(FieldTable::default);
 
         // Increment the number of retries.
         let retries = match get_header_u32(&headers, "retries") {

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -316,12 +316,12 @@ impl Broker for AMQPBroker {
     async fn increase_prefetch_count(&self) -> Result<(), BrokerError> {
         let new_count = {
             let mut prefetch_count = self.prefetch_count.lock().await;
-            if *prefetch_count < std::u16::MAX {
+            if *prefetch_count < u16::MAX {
                 let new_count = *prefetch_count + 1;
                 *prefetch_count = new_count;
                 new_count
             } else {
-                std::u16::MAX
+                u16::MAX
             }
         };
         self.set_prefetch_count(new_count).await?;

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -218,6 +218,10 @@ impl Broker for AMQPBroker {
             .map_err(|e| e.into())
     }
 
+    async fn nack(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+        Ok(())
+    }
+
     async fn retry(
         &self,
         delivery: &Self::Delivery,

--- a/src/broker/amqp.rs
+++ b/src/broker/amqp.rs
@@ -221,7 +221,8 @@ impl Broker for AMQPBroker {
     async fn nack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError> {
         delivery
             .1
-            .reject(BasicRejectOptions::default())
+            //.reject(BasicRejectOptions::default())
+            .reject(BasicRejectOptions { requeue: true })
             .await
             .map_err(|e| e.into())
     }

--- a/src/broker/mock.rs
+++ b/src/broker/mock.rs
@@ -94,6 +94,10 @@ impl Broker for MockBroker {
         Ok(())
     }
 
+    async fn nack(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+        Ok(())
+    }
+
     #[allow(unused)]
     async fn retry(
         &self,

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -65,6 +65,9 @@ pub trait Broker: Send + Sync + Sized {
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.
     async fn ack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError>;
 
+    /// Negative acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for requeue.
+    async fn nack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError>;
+
     /// Retry a delivery.
     async fn retry(
         &self,
@@ -88,6 +91,11 @@ pub trait Broker: Send + Sync + Sized {
 
     /// Try reconnecting in the event of some sort of connection error.
     async fn reconnect(&self, connection_timeout: u32) -> Result<(), BrokerError>;
+
+    /// Callback used to notify that a certain task's message was processed
+    fn on_message_processed(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+        Ok(())
+    }
 }
 
 /// A [`BrokerBuilder`] is used to create a type of broker with a custom configuration.

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -93,7 +93,7 @@ pub trait Broker: Send + Sync + Sized {
     async fn reconnect(&self, connection_timeout: u32) -> Result<(), BrokerError>;
 
     /// Callback used to notify that a certain task's message was processed
-    fn on_message_processed(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+    async fn on_message_processed(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
         Ok(())
     }
 }

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -65,7 +65,7 @@ pub trait Broker: Send + Sync + Sized {
     /// Acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for deletion.
     async fn ack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError>;
 
-    /// Negative acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery) for requeue.
+    /// Negative acknowledge a [`Delivery`](trait.Broker.html#associatedtype.Delivery).
     async fn nack(&self, delivery: &Self::Delivery) -> Result<(), BrokerError>;
 
     /// Retry a delivery.
@@ -92,7 +92,7 @@ pub trait Broker: Send + Sync + Sized {
     /// Try reconnecting in the event of some sort of connection error.
     async fn reconnect(&self, connection_timeout: u32) -> Result<(), BrokerError>;
 
-    /// Callback used to notify that a certain task's message was processed
+    /// Indicates that a message has been processed.
     async fn on_message_processed(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
         Ok(())
     }

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -323,6 +323,7 @@ impl Broker for RedisBroker {
     }
 
     async fn nack(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+        warn!("It does not make sense to negative awknoledge a message. Change the configuration.");
         Ok(())
     }
 

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -322,6 +322,10 @@ impl Broker for RedisBroker {
         Ok(())
     }
 
+    async fn nack(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
+        Ok(())
+    }
+
     /// Retry a delivery.
     async fn retry(
         &self,

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -171,7 +171,7 @@ impl Channel {
                         delivery.properties.delivery_tag, delivery.headers.task
                     );
                     let _set_rez: u32 = redis::cmd("HSET")
-                        .arg(&self.process_map_name())
+                        .arg(self.process_map_name())
                         .arg(&delivery.properties.correlation_id)
                         .arg(&rez)
                         .query_async(&mut self.connection)
@@ -201,7 +201,7 @@ impl Channel {
 
     async fn remove_task(&self, delivery: &Delivery) -> Result<(), BrokerError> {
         redis::cmd("HDEL")
-            .arg(&self.process_map_name())
+            .arg(self.process_map_name())
             .arg(&delivery.properties.correlation_id)
             .query_async::<ConnectionManager, ()>(&mut self.connection.clone())
             .await?;

--- a/src/broker/redis.rs
+++ b/src/broker/redis.rs
@@ -323,7 +323,7 @@ impl Broker for RedisBroker {
     }
 
     async fn nack(&self, _delivery: &Self::Delivery) -> Result<(), BrokerError> {
-        warn!("It does not make sense to negative awknoledge a message. Change the configuration.");
+        warn!("Negative acknowledges not supported.");
         Ok(())
     }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -103,6 +103,8 @@ macro_rules! __beat_internal {
 /// - `task_max_retry_delay`: Set an app-level [`TaskOptions::max_retry_delay`](task/struct.TaskOptions.html#structfield.max_retry_delay).
 /// - `task_retry_for_unexpected`: Set an app-level [`TaskOptions::retry_for_unexpected`](task/struct.TaskOptions.html#structfield.retry_for_unexpected).
 /// - `acks_late`: Set an app-level [`TaskOptions::acks_late`](task/struct.TaskOptions.html#structfield.acks_late).
+/// - `acks_on_failure_or_timeout`: Set an app-level [`TaskOptions::acks_on_failure_or_timeout`](task/struct.TaskOptions.html#structfield.acks_on_failure_or_timeout).
+/// - `nacks_enabled`: Set an app-level [`TaskOptions::nacks_enabled`](task/struct.TaskOptions.html#structfield.nacks_enabled).
 /// - `broker_connection_timeout`: Set the
 /// [`CeleryBuilder::broker_connection_timeout`](struct.CeleryBuilder.html#method.broker_connection_timeout).
 /// - `broker_connection_retry`: Set the

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -93,7 +93,7 @@ macro_rules! __beat_internal {
 /// [`CeleryBuilder`](struct.CeleryBuilder.html) struct):
 ///
 /// - `default_queue`: Set the
-/// [`CeleryBuilder::default_queue`](struct.CeleryBuilder.html#method.default_queue).
+///   [`CeleryBuilder::default_queue`](struct.CeleryBuilder.html#method.default_queue).
 /// - `prefetch_count`: Set the [`CeleryBuilder::prefect_count`](struct.CeleryBuilder.html#method.prefect_count).
 /// - `heartbeat`: Set the [`CeleryBuilder::heartbeat`](struct.CeleryBuilder.html#method.heartbeat).
 /// - `task_time_limit`: Set an app-level [`TaskOptions::time_limit`](task/struct.TaskOptions.html#structfield.time_limit).
@@ -106,11 +106,11 @@ macro_rules! __beat_internal {
 /// - `acks_on_failure_or_timeout`: Set an app-level [`TaskOptions::acks_on_failure_or_timeout`](task/struct.TaskOptions.html#structfield.acks_on_failure_or_timeout).
 /// - `nacks_enabled`: Set an app-level [`TaskOptions::nacks_enabled`](task/struct.TaskOptions.html#structfield.nacks_enabled).
 /// - `broker_connection_timeout`: Set the
-/// [`CeleryBuilder::broker_connection_timeout`](struct.CeleryBuilder.html#method.broker_connection_timeout).
+///   [`CeleryBuilder::broker_connection_timeout`](struct.CeleryBuilder.html#method.broker_connection_timeout).
 /// - `broker_connection_retry`: Set the
-/// [`CeleryBuilder::broker_connection_retry`](struct.CeleryBuilder.html#method.broker_connection_retry).
+///   [`CeleryBuilder::broker_connection_retry`](struct.CeleryBuilder.html#method.broker_connection_retry).
 /// - `broker_connection_max_retries`: Set the
-/// [`CeleryBuilder::broker_connection_max_retries`](struct.CeleryBuilder.html#method.broker_connection_max_retries).
+///   [`CeleryBuilder::broker_connection_max_retries`](struct.CeleryBuilder.html#method.broker_connection_max_retries).
 ///
 /// # Examples
 ///
@@ -194,14 +194,14 @@ macro_rules! app {
 /// (all of which correspond to a method on the [`BeatBuilder`](beat/struct.BeatBuilder.html) struct):
 ///
 /// - `default_queue`: Set the
-/// [`BeatBuilder::default_queue`](beat/struct.BeatBuilder.html#method.default_queue).
+///   [`BeatBuilder::default_queue`](beat/struct.BeatBuilder.html#method.default_queue).
 /// - `heartbeat`: Set the [`BeatBuilder::heartbeat`](beat/struct.BeatBuilder.html#method.heartbeat).
 /// - `broker_connection_timeout`: Set the
-/// [`BeatBuilder::broker_connection_timeout`](beat/struct.BeatBuilder.html#method.broker_connection_timeout).
+///   [`BeatBuilder::broker_connection_timeout`](beat/struct.BeatBuilder.html#method.broker_connection_timeout).
 /// - `broker_connection_retry`: Set the
-/// [`BeatBuilder::broker_connection_retry`](beat/struct.BeatBuilder.html#method.broker_connection_retry).
+///   [`BeatBuilder::broker_connection_retry`](beat/struct.BeatBuilder.html#method.broker_connection_retry).
 /// - `broker_connection_max_retries`: Set the
-/// [`BeatBuilder::broker_connection_max_retries`](beat/struct.BeatBuilder.html#method.broker_connection_max_retries).
+///   [`BeatBuilder::broker_connection_max_retries`](beat/struct.BeatBuilder.html#method.broker_connection_max_retries).
 ///
 /// # Examples
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum CeleryError {
 
     #[error("received unregistered task {0}")]
     UnregisteredTaskError(String),
+
+    #[error("configuration error: {0}")]
+    ConfigurationError(String),
 }
 
 /// Errors that can occur while creating or using a `Beat` app.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,8 @@ mod codegen;
 /// - `max_retry_delay`: Set a task-level [`TaskOptions::max_retry_delay`](task/struct.TaskOptions.html#structfield.max_retry_delay).
 /// - `retry_for_unexpected`: Set a task-level [`TaskOptions::retry_for_unexpected`](task/struct.TaskOptions.html#structfield.retry_for_unexpected).
 /// - `acks_late`: Set a task-level [`TaskOptions::acks_late`](task/struct.TaskOptions.html#structfield.acks_late).
+/// - `acks_on_failure_or_timeout`: Set a task-level [`TaskOptions::acks_on_failure_or_timeout`](task/struct.TaskOptions.html#structfield.acks_on_failure_or_timeout).
+/// - `nacks_enabled`: Set a task-level [`TaskOptions::nacks_enabled`](task/struct.TaskOptions.html#structfield.nacks_enabled).
 /// - `content_type`: Set a task-level [`TaskOptions::content_type`](task/struct.TaskOptions.html#structfield.content_type).
 /// - `bind`: A bool. If true, the task will be run like an instance method and so the function's
 /// first argument should be a reference to `Self`. Note however that Rust won't allow you to call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ mod codegen;
 /// # Parameters
 ///
 /// - `name`: The name to use when registering the task. Should be unique. If not given the name
-/// will be set to the name of the function being decorated.
+///   will be set to the name of the function being decorated.
 /// - `time_limit`: Set a task-level [`TaskOptions::time_limit`](task/struct.TaskOptions.html#structfield.time_limit).
 /// - `hard_time_limit`: Set a task-level [`TaskOptions::hard_time_limit`](task/struct.TaskOptions.html#structfield.hard_time_limit).
 /// - `max_retries`: Set a task-level [`TaskOptions::max_retries`](task/struct.TaskOptions.html#structfield.max_retries).
@@ -119,12 +119,12 @@ mod codegen;
 /// - `nacks_enabled`: Set a task-level [`TaskOptions::nacks_enabled`](task/struct.TaskOptions.html#structfield.nacks_enabled).
 /// - `content_type`: Set a task-level [`TaskOptions::content_type`](task/struct.TaskOptions.html#structfield.content_type).
 /// - `bind`: A bool. If true, the task will be run like an instance method and so the function's
-/// first argument should be a reference to `Self`. Note however that Rust won't allow you to call
-/// the argument `self`. Instead, you could use `task` or just `t`.
+///   first argument should be a reference to `Self`. Note however that Rust won't allow you to call
+///   the argument `self`. Instead, you could use `task` or just `t`.
 /// - `on_failure`: An async callback function to run when the task fails. Should accept a reference to
-/// a task instance and a reference to a [`TaskError`](error/enum.TaskError.html).
+///   a task instance and a reference to a [`TaskError`](error/enum.TaskError.html).
 /// - `on_success`: An async callback function to run when the task succeeds. Should accept a reference to
-/// a task instance and a reference to the value returned by the task.
+///   a task instance and a reference to the value returned by the task.
 ///
 /// For more information see the [tasks chapter](https://rusty-celery.github.io/guide/defining-tasks.html)
 /// in the Rusty Celery Book.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,7 @@
 //! Defines the Celery protocol.
 //!
 //! The top part of the protocol is the [`Message`] struct, which builds on
-//! top of the protocol for a broker. This is why a broker's [`Delivery`](crate::broker::Broker::Delivery)
+//! top of the protocol for a broker. This is why a broker's [`Delivery`](crate::broker::Delivery)
 //! type must implement [`TryCreateMessage`].
 
 use base64::{
@@ -569,7 +569,7 @@ where
 }
 
 /// A trait for attempting to deserialize a [`Message`] from `self`. This is required to be implemented
-/// on a broker's [`Delivery`](crate::broker::Broker::Delivery) type.
+/// on a broker's [`Delivery`](crate::broker::Delivery) type.
 pub trait TryDeserializeMessage {
     fn try_deserialize_message(&self) -> Result<Message, ProtocolError>;
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,7 +1,7 @@
 //! Provides the [`Task`] trait as well as options for configuring tasks.
 
 use async_trait::async_trait;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use rand::distributions::{Distribution, Uniform};
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -117,7 +117,8 @@ pub trait Task: Send + Sync + std::marker::Sized {
                 let now_millis = now.subsec_millis();
                 let eta_secs = now_secs + countdown;
                 Some(DateTime::<Utc>::from_naive_utc_and_offset(
-                    NaiveDateTime::from_timestamp_opt(eta_secs as i64, now_millis * 1000)
+                    DateTime::from_timestamp(eta_secs as i64, now_millis * 1000)
+                        .map(|eta| eta.naive_utc())
                         .ok_or_else(|| {
                             TaskError::UnexpectedError(format!(
                                 "Invalid countdown seconds {countdown}",
@@ -155,7 +156,8 @@ pub trait Task: Send + Sync + std::marker::Sized {
                 let now_millis = now.subsec_millis();
                 let eta_secs = now_secs + delay_secs;
                 let eta_millis = now_millis + delay_millis;
-                NaiveDateTime::from_timestamp_opt(eta_secs as i64, eta_millis * 1000)
+                DateTime::from_timestamp(eta_secs as i64, eta_millis * 1000)
+                    .map(|eta| eta.naive_utc())
                     .map(|eta| DateTime::<Utc>::from_naive_utc_and_offset(eta, Utc))
             }
             Err(_) => None,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -14,7 +14,7 @@ mod request;
 mod signature;
 
 pub use async_result::AsyncResult;
-pub use options::TaskOptions;
+pub use options::{TaskOptions, TaskOptionsConcreteDefault};
 pub use request::Request;
 pub use signature::Signature;
 
@@ -57,6 +57,8 @@ pub trait Task: Send + Sync + std::marker::Sized {
         max_retry_delay: None,
         retry_for_unexpected: None,
         acks_late: None,
+        acks_on_failure_or_timeout: None,
+        nacks_enabled: None,
         content_type: None,
     };
 
@@ -187,21 +189,35 @@ pub trait Task: Send + Sync + std::marker::Sized {
         Self::DEFAULTS
             .min_retry_delay
             .or(self.options().min_retry_delay)
-            .unwrap_or(0)
+            .unwrap_or_else(TaskOptionsConcreteDefault::min_retry_delay)
     }
 
     fn max_retry_delay(&self) -> u32 {
         Self::DEFAULTS
             .max_retry_delay
             .or(self.options().max_retry_delay)
-            .unwrap_or(3600)
+            .unwrap_or_else(TaskOptionsConcreteDefault::max_retry_delay)
     }
 
     fn acks_late(&self) -> bool {
         Self::DEFAULTS
             .acks_late
             .or(self.options().acks_late)
-            .unwrap_or(false)
+            .unwrap_or_else(TaskOptionsConcreteDefault::acks_late)
+    }
+
+    fn acks_on_failure_or_timeout(&self) -> bool {
+        Self::DEFAULTS
+            .acks_on_failure_or_timeout
+            .or(self.options().acks_on_failure_or_timeout)
+            .unwrap_or_else(TaskOptionsConcreteDefault::acks_on_failure_or_timeout)
+    }
+
+    fn nacks_enabled(&self) -> bool {
+        Self::DEFAULTS
+            .nacks_enabled
+            .or(self.options().nacks_enabled)
+            .unwrap_or_else(TaskOptionsConcreteDefault::nacks_enabled)
     }
 }
 

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -108,7 +108,7 @@ pub struct TaskOptions {
     /// fails or times out
     ///
     /// Configuring this setting only applies to tasks that are acknowledged **after** they
-    /// have been executed and only if [`task_acks_late`] is enabled.
+    /// have been executed and only if [`acks_late`](crate::CeleryBuilder::acks_late) is enabled.
     ///
     /// This can be set with
     /// - [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) at the app level, and
@@ -122,8 +122,8 @@ pub struct TaskOptions {
     /// fails or times out
     ///
     /// Configuring this setting only applies to tasks that are acknowledged **after** they
-    /// have been executed and only if [`task_acks_late`] is enabled and [`task_acks_on_failure_or_timeout`]
-    /// is disabled.
+    /// have been executed and only if [`acks_late`](crate::CeleryBuilder::acks_late) is enabled
+    /// and [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) is disabled.
     ///
     /// This can be set with
     /// - [`nacks_enabled`](crate::CeleryBuilder::nacks_enabled) at the app level, and

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -104,6 +104,34 @@ pub struct TaskOptions {
     /// If this option is left unspecified, the default behavior will be to ack early.
     pub acks_late: Option<bool>,
 
+    /// When enabled messages for this task will be acknowledged even if it
+    /// fails or times out
+    ///
+    /// Configuring this setting only applies to tasks that are acknowledged **after** they
+    /// have been executed and only if [`task_acks_late`] is enabled.
+    ///
+    /// This can be set with
+    /// - [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) at the app level, and
+    /// - [`acks_on_failure_or_timeout`](../attr.task.html#parameters) at the task level.
+    ///
+    /// If this option is left unspecified, the default behavior will be to acknowledge the message
+    /// even if they fail.
+    pub acks_on_failure_or_timeout: Option<bool>,
+
+    /// When enabled messages for this task will be negatively acknowledged if it
+    /// fails or times out
+    ///
+    /// Configuring this setting only applies to tasks that are acknowledged **after** they
+    /// have been executed and only if [`task_acks_late`] is enabled and [`acks_on_failure_or_timeout`]
+    /// is disabled.
+    ///
+    /// This can be set with
+    /// - [`nacks_enabled`](crate::CeleryBuilder::nacks_enabled) at the app level, and
+    /// - [`nacks_enabled`](../attr.task.html#parameters) at the task level.
+    ///
+    /// If this option is left unspecified, the default behavior will be to omit the negative acknowledge
+    pub nacks_enabled: Option<bool>,
+
     /// Which serialization format to use for task messages.
     ///
     /// This can be set with
@@ -123,12 +151,67 @@ impl TaskOptions {
         self.max_retry_delay = self.max_retry_delay.or(other.max_retry_delay);
         self.retry_for_unexpected = self.retry_for_unexpected.or(other.retry_for_unexpected);
         self.acks_late = self.acks_late.or(other.acks_late);
+        self.acks_on_failure_or_timeout = self
+            .acks_on_failure_or_timeout
+            .or(other.acks_on_failure_or_timeout);
+        self.nacks_enabled = self.nacks_enabled.or(other.nacks_enabled);
         self.content_type = self.content_type.or(other.content_type);
     }
 
     /// Override the fields in `other` with the fields in `self`.
     pub(crate) fn override_other(&self, other: &mut TaskOptions) {
         other.update(self);
+    }
+}
+
+/// The objetive of this struct is to centralize the concrete default values that have
+/// the same behaviour as if the configuration was not defined (with None variant of Option<> enum)
+///
+/// Instread of writing:
+/// ```rust
+/// use celery::task::TaskOptions;
+///
+/// let config = TaskOptions::default();
+/// config
+///     .acks_late
+///     .unwrap_or(false);
+/// ```
+///
+/// We write
+///
+/// ```rust
+/// use celery::task::{TaskOptions, TaskOptionsConcreteDefault};
+///
+/// let config = TaskOptions::default();
+/// config
+///     .acks_late
+///     .unwrap_or_else(TaskOptionsConcreteDefault::acks_late);
+/// ```
+pub struct TaskOptionsConcreteDefault;
+
+impl TaskOptionsConcreteDefault {
+    pub fn retry_for_unexpected() -> bool {
+        true
+    }
+
+    pub fn min_retry_delay() -> u32 {
+        0
+    }
+
+    pub fn max_retry_delay() -> u32 {
+        3600
+    }
+
+    pub fn acks_late() -> bool {
+        false
+    }
+
+    pub fn acks_on_failure_or_timeout() -> bool {
+        true
+    }
+
+    pub fn nacks_enabled() -> bool {
+        false
     }
 }
 
@@ -141,12 +224,16 @@ mod tests {
         let mut options = TaskOptions {
             max_retries: Some(3),
             acks_late: Some(true),
+            acks_on_failure_or_timeout: Some(true),
+            nacks_enabled: Some(true),
             ..Default::default()
         };
 
         let other = TaskOptions {
             time_limit: Some(2),
             acks_late: Some(false),
+            acks_on_failure_or_timeout: Some(false),
+            nacks_enabled: Some(false),
             ..Default::default()
         };
 
@@ -154,5 +241,7 @@ mod tests {
         assert_eq!(options.time_limit, Some(2));
         assert_eq!(options.max_retries, Some(3));
         assert_eq!(options.acks_late, Some(true));
+        assert_eq!(options.acks_on_failure_or_timeout, Some(true));
+        assert_eq!(options.nacks_enabled, Some(true));
     }
 }

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -108,7 +108,7 @@ pub struct TaskOptions {
     /// fails or times out
     ///
     /// Configuring this setting only applies to tasks that are acknowledged **after** they
-    /// have been executed and only if [`acks_late`](crate::CeleryBuilder::acks_late) is enabled.
+    /// have been executed and only if [`acks_late`](../attr.task.html#parameters) is enabled.
     ///
     /// This can be set with
     /// - [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) at the app level, and
@@ -122,8 +122,8 @@ pub struct TaskOptions {
     /// fails or times out
     ///
     /// Configuring this setting only applies to tasks that are acknowledged **after** they
-    /// have been executed and only if [`acks_late`](crate::CeleryBuilder::acks_late) is enabled
-    /// and [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) is disabled.
+    /// have been executed and only if [`acks_late`](../attr.task.html#parameters) is enabled
+    /// and [`acks_on_failure_or_timeout`](../attr.task.html#parameters) is disabled.
     ///
     /// This can be set with
     /// - [`nacks_enabled`](crate::CeleryBuilder::nacks_enabled) at the app level, and

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -122,7 +122,7 @@ pub struct TaskOptions {
     /// fails or times out
     ///
     /// Configuring this setting only applies to tasks that are acknowledged **after** they
-    /// have been executed and only if [`task_acks_late`] is enabled and [`acks_on_failure_or_timeout`]
+    /// have been executed and only if [`task_acks_late`] is enabled and [`task_acks_on_failure_or_timeout`]
     /// is disabled.
     ///
     /// This can be set with

--- a/src/task/options.rs
+++ b/src/task/options.rs
@@ -114,8 +114,8 @@ pub struct TaskOptions {
     /// - [`acks_on_failure_or_timeout`](crate::CeleryBuilder::acks_on_failure_or_timeout) at the app level, and
     /// - [`acks_on_failure_or_timeout`](../attr.task.html#parameters) at the task level.
     ///
-    /// If this option is left unspecified, the default behavior will be to acknowledge the message
-    /// even if they fail.
+    /// If this option is left unspecified, the default behavior will be to acknowledge messages
+    /// for this task even if it fails.
     pub acks_on_failure_or_timeout: Option<bool>,
 
     /// When enabled messages for this task will be negatively acknowledged if it
@@ -164,10 +164,11 @@ impl TaskOptions {
     }
 }
 
-/// The objetive of this struct is to centralize the concrete default values that have
-/// the same behaviour as if the configuration was not defined (with None variant of Option<> enum)
+/// This struct aims for centralizing the concrete default values.
 ///
-/// Instread of writing:
+/// These values behave as if the configuration was not defined.
+///
+/// Instead of writing:
 /// ```rust
 /// use celery::task::TaskOptions;
 ///


### PR DESCRIPTION
This PR adds the `acks_on_failure` and `nacks_enabled` task options.

This is the [feature/acks_on_failure__and__nacks](https://github.com/Mighty-Block/rusty-celery/tree/feature/acks_on_failure__and__nacks) branch @nicoan mentioned [here](https://github.com/rusty-celery/rusty-celery/issues/291#issuecomment-1016855057) updated to the latest APIs. All credit due to the original author(s).

Closes #291 and maybe #374?